### PR TITLE
Add dev.sh command-line dev tool for the calibre plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this repo is
+This is **"Ask AI Plugin"**, a GUI plugin for the [calibre](https://calibre-ebook.com/)
+e-book manager. It is a single Python package (not a monorepo) whose runtime is
+calibre's bundled Python + PyQt. Third-party deps are **vendored** in
+`lib/ask_ai_plugin_vendor/`, so `requirements.txt` is dev-reference only and is
+not required at runtime.
+
+### Environment (already provisioned; not part of the update script)
+- **calibre** is installed as a system app (`/opt/calibre`, provides
+  `calibre`, `calibre-customize`, `calibre-debug`, `calibredb`). It is a system
+  dependency and persists in the VM snapshot, so it is intentionally NOT in the
+  update script.
+- GUI system libs (`libegl1`, `libopengl0`, `libxcb-*`, etc.) are installed so
+  calibre's Qt GUI can start; a virtual display is available on `DISPLAY=:1`, and
+  `xvfb-run` works for headless runs.
+
+### Command-line dev tool: `./dev.sh`
+`dev.sh` wraps the calibre CLI so the whole loop runs from the terminal:
+- `./dev.sh build` – rebuild + reinstall the plugin (`calibre-customize -b .`).
+- `./dev.sh run` – launch the calibre GUI (uses `DISPLAY`, else `xvfb-run`).
+- `./dev.sh run-headless` – launch the GUI under `xvfb-run` (no display needed).
+- `./dev.sh smoke` – isolated headless build+load check; exits non-zero if the
+  plugin fails to load. Good CI-style sanity check.
+- `./dev.sh compile` – fast `py_compile` syntax check of plugin sources.
+- `./dev.sh library` – create the dev library (`~/calibre-library`) + a sample book.
+- `./dev.sh logs` – show the plugin's log directory.
+
+### Non-obvious gotchas
+- **First-run migration bug on `main`:** `config.get_prefs()` references an
+  unbound local `logger` in the fresh-config migration branch (fixed on `dev`).
+  On a brand-new calibre config the very first plugin load raises
+  `UnboundLocalError` and calibre exits. It **self-heals**: the crashing launch
+  writes `use_interface_language` to `plugins/ask_ai_plugin.json` before it
+  fails, so the *second* launch loads fine. Alternatively, seed
+  `<calibre-config>/plugins/ask_ai_plugin.json` with
+  `{"use_interface_language": false}`. `./dev.sh smoke` seeds this automatically.
+- **`DeviceScanner requires the /sys filesystem` traceback** at startup is a
+  harmless background device-detection thread error in the container; it does
+  **not** affect the plugin.
+- **`calibredb`/`calibre` on the same library:** running a `calibredb` command
+  while the calibre GUI is open prints a "another calibre program is running"
+  warning because the GUI holds the library lock. Close the GUI or use a
+  separate `--with-library` path.
+- The `calibre_plugins.*` namespace only exists inside a running calibre; you
+  cannot `import calibre_plugins.ask_ai_plugin` from a plain `calibre-debug -c`
+  one-liner.
+- Fully exercising an AI answer needs a configured provider API key
+  (OpenAI/Anthropic/Gemini/etc.); the default "Nvidia Free" provider routes
+  through an external proxy and requires network access.

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# dev.sh - Command-line development tool for the "Ask AI Plugin" calibre plugin.
+#
+# This wraps calibre's CLI (calibre-customize / calibre / calibredb) so the
+# whole dev loop (build -> run -> smoke test) can be driven from the terminal,
+# including on headless machines via xvfb-run.
+#
+# Usage:
+#   ./dev.sh build            Rebuild + (re)install the plugin into calibre
+#   ./dev.sh run              Launch the calibre GUI with the dev library
+#   ./dev.sh run-headless     Launch the calibre GUI under xvfb (no display needed)
+#   ./dev.sh smoke            Headless, isolated smoke test: build + load + check
+#   ./dev.sh compile          Fast syntax check (py_compile) of all plugin sources
+#   ./dev.sh library          Create the dev library + a sample book if missing
+#   ./dev.sh logs             Print the plugin's log directory contents
+#   ./dev.sh help             Show this help
+#
+# Environment variables:
+#   CALIBRE_LIBRARY   Path to the dev calibre library (default: ~/calibre-library)
+#   DISPLAY           If set, 'run' uses it; otherwise falls back to xvfb-run.
+
+set -euo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CALIBRE_LIBRARY="${CALIBRE_LIBRARY:-$HOME/calibre-library}"
+SAMPLE_TITLE="The Adventures of Sherlock Holmes"
+SAMPLE_AUTHOR="Arthur Conan Doyle"
+
+log()  { printf '\033[1;34m[dev]\033[0m %s\n' "$*"; }
+err()  { printf '\033[1;31m[dev:error]\033[0m %s\n' "$*" >&2; }
+
+require() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        err "required command '$1' not found. Is calibre installed and on PATH?"
+        exit 127
+    fi
+}
+
+cmd_build() {
+    require calibre-customize
+    log "Building + installing plugin from $PLUGIN_DIR"
+    calibre-customize -b "$PLUGIN_DIR"
+}
+
+cmd_compile() {
+    log "Compiling all plugin Python sources (syntax check)"
+    # Only check the plugin's own top-level sources, skip vendored libs.
+    python3 - "$PLUGIN_DIR" <<'PY'
+import sys, os, py_compile, glob
+root = sys.argv[1]
+failed = False
+for path in sorted(glob.glob(os.path.join(root, "*.py"))):
+    try:
+        py_compile.compile(path, doraise=True)
+    except py_compile.PyCompileError as e:
+        failed = True
+        print(f"FAIL {path}: {e}")
+for sub in ("models", "aiprovider"):
+    for path in sorted(glob.glob(os.path.join(root, sub, "*.py"))):
+        try:
+            py_compile.compile(path, doraise=True)
+        except py_compile.PyCompileError as e:
+            failed = True
+            print(f"FAIL {path}: {e}")
+if failed:
+    sys.exit(1)
+print("OK: all top-level plugin sources compile")
+PY
+}
+
+cmd_library() {
+    require calibredb
+    if [ -f "$CALIBRE_LIBRARY/metadata.db" ]; then
+        log "Dev library already exists at $CALIBRE_LIBRARY"
+    else
+        log "Creating dev library at $CALIBRE_LIBRARY with a sample book"
+        mkdir -p "$CALIBRE_LIBRARY"
+        local tmp
+        tmp="$(mktemp -d)"
+        cat > "$tmp/sample.html" <<HTML
+<html><head><title>${SAMPLE_TITLE}</title></head>
+<body><h1>${SAMPLE_TITLE}</h1><p>By ${SAMPLE_AUTHOR}</p>
+<p>To Sherlock Holmes she is always the woman.</p></body></html>
+HTML
+        ebook-convert "$tmp/sample.html" "$tmp/sample.epub" \
+            --authors="$SAMPLE_AUTHOR" --title="$SAMPLE_TITLE" >/dev/null 2>&1
+        calibredb add "$tmp/sample.epub" --with-library "$CALIBRE_LIBRARY" >/dev/null
+        rm -rf "$tmp"
+    fi
+    calibredb list --with-library "$CALIBRE_LIBRARY"
+}
+
+cmd_run() {
+    require calibre
+    cmd_library >/dev/null || true
+    if [ -n "${DISPLAY:-}" ]; then
+        log "Launching calibre GUI on DISPLAY=$DISPLAY (library: $CALIBRE_LIBRARY)"
+        exec calibre --with-library "$CALIBRE_LIBRARY"
+    else
+        log "No DISPLAY set; launching under xvfb-run"
+        cmd_run_headless
+    fi
+}
+
+cmd_run_headless() {
+    require calibre
+    require xvfb-run
+    cmd_library >/dev/null || true
+    log "Launching calibre GUI headless via xvfb-run (library: $CALIBRE_LIBRARY)"
+    exec xvfb-run -a calibre --with-library "$CALIBRE_LIBRARY"
+}
+
+cmd_smoke() {
+    require calibre
+    require calibre-customize
+    require xvfb-run
+    require timeout
+    local cfg lib rc=0
+    cfg="$(mktemp -d)"
+    lib="$(mktemp -d)"
+    log "Smoke test in isolated config dir: $cfg"
+
+    CALIBRE_CONFIG_DIRECTORY="$cfg" calibre-customize -b "$PLUGIN_DIR" >/dev/null
+    # Seed the plugin config so the fresh-config migration path in config.py
+    # (which references an unbound 'logger' on main) does not crash on first load.
+    mkdir -p "$cfg/plugins"
+    printf '{\n  "use_interface_language": false\n}\n' > "$cfg/plugins/ask_ai_plugin.json"
+
+    local logf="$cfg/smoke.log"
+    log "Launching calibre headless (up to 40s) to verify plugin loads"
+    CALIBRE_CONFIG_DIRECTORY="$cfg" timeout 40 xvfb-run -a \
+        calibre --with-library "$lib" > "$logf" 2>&1 &
+    local pid=$!
+    sleep 22
+    kill "$pid" 2>/dev/null || true
+    pkill -P "$pid" 2>/dev/null || true
+    sleep 2
+
+    if grep -q "ask_ai_plugin" "$logf" && grep -qi "traceback" "$logf"; then
+        err "Plugin raised an error during load:"
+        grep -A20 -i "traceback" "$logf" >&2 || true
+        rc=1
+    fi
+
+    if CALIBRE_CONFIG_DIRECTORY="$cfg" calibre-customize --list-plugins 2>/dev/null \
+        | grep -qi "ask ai"; then
+        log "Plugin is registered."
+    else
+        err "Plugin is NOT registered."
+        rc=1
+    fi
+
+    rm -rf "$cfg" "$lib"
+    if [ "$rc" -eq 0 ]; then
+        log "SMOKE PASS: plugin builds and loads cleanly."
+    else
+        err "SMOKE FAIL."
+    fi
+    return "$rc"
+}
+
+cmd_logs() {
+    local dir="$HOME/.config/calibre/plugins/ask_ai_plugin_logs"
+    if [ -d "$dir" ]; then
+        log "Plugin logs in $dir:"
+        ls -la "$dir"
+    else
+        log "No plugin log directory found at $dir yet."
+    fi
+}
+
+cmd_help() {
+    sed -n '3,21p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+main() {
+    local sub="${1:-help}"
+    shift || true
+    case "$sub" in
+        build)         cmd_build "$@" ;;
+        compile)       cmd_compile "$@" ;;
+        library)       cmd_library "$@" ;;
+        run)           cmd_run "$@" ;;
+        run-headless)  cmd_run_headless "$@" ;;
+        smoke)         cmd_smoke "$@" ;;
+        logs)          cmd_logs "$@" ;;
+        help|-h|--help) cmd_help ;;
+        *) err "unknown command: $sub"; echo; cmd_help; exit 2 ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a command-line development tool (`dev.sh`) so the whole dev loop for this calibre GUI plugin (build → run → smoke test) can be driven from the terminal, including headless via `xvfb-run`. Also adds `AGENTS.md` with Cursor Cloud setup notes and known gotchas.

## `dev.sh` subcommands
- `build` – rebuild + reinstall the plugin (`calibre-customize -b .`)
- `run` – launch the calibre GUI (uses `DISPLAY`, else falls back to `xvfb-run`)
- `run-headless` – launch the GUI under `xvfb-run` (no display needed)
- `smoke` – isolated headless build+load check; exits non-zero if the plugin fails to load
- `compile` – fast `py_compile` syntax check of plugin sources
- `library` – create the dev library (`~/calibre-library`) + a sample book
- `logs` – show the plugin's log directory

## Notes
- No plugin/runtime code was modified — this only adds tooling and docs.
- `AGENTS.md` documents a known first-run gotcha: `config.get_prefs()` references an unbound `logger` in the fresh-config migration branch on `main` (fixed on `dev`); it self-heals on the second launch, and `dev.sh smoke` seeds the config to avoid it.

## Evidence
Command-line dev tool running end-to-end (compile + build + headless smoke test passing):
[dev_tool_output.log](https://cursor.com/agents/bc-12f3b67e-0c14-480d-a84c-2b2d8b9fc5e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_tool_output.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12f3b67e-0c14-480d-a84c-2b2d8b9fc5e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12f3b67e-0c14-480d-a84c-2b2d8b9fc5e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

