### PR TITLE
Add Mistral AI provider with API key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ask AI Plugin(old name: Ask Grok)
 
-A simple calibre plugin that allows users to ask questions about books using various AI models including OpenAI, Anthropic Claude, Google Gemini, Grok, DeepSeek, Nvidia AI, Perplexity (Sonar), OpenRouter, Ollama, and custom AI providers.
+A simple calibre plugin that allows users to ask questions about books using various AI models including OpenAI, Anthropic Claude, Google Gemini, Grok, DeepSeek, Mistral, Nvidia AI, Perplexity (Sonar), OpenRouter, Ollama, and custom AI providers.
 
 ## Preview
 
@@ -44,6 +44,7 @@ Import the file to calibre custom plugins:
 - **Google Gemini** - https://aistudio.google.com/
 - **Grok (x.AI)** - https://console.x.ai/
 - **DeepSeek** - https://platform.deepseek.com/
+- **Mistral** - https://console.mistral.ai/
 - **Nvidia AI** - https://build.nvidia.com/ (Free tier available)
 - **Perplexity (Sonar)** - https://docs.perplexity.ai/ (Great for research-style answers with citations)
 - **OpenRouter** - https://openrouter.ai/
@@ -72,7 +73,7 @@ API Key:
 ## Configure API Key
 
   - Click the Ask AI Plugin dropdown menu in the menu bar, select `Configure`
-  - Select the AI provider you want to use (OpenAI, Anthropic, Gemini, Grok, DeepSeek, Nvidia, OpenRouter, Ollama, or Custom)
+  - Select the AI provider you want to use (OpenAI, Anthropic, Gemini, Grok, DeepSeek, Mistral, Nvidia, OpenRouter, Ollama, or Custom)
   - Enter the corresponding API Key into the API Key input box
   - Click the `Save` button
   - Done

--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@ PLUGIN_NAME = 'Ask AI Plugin'
 PLUGIN_DESCRIPTION = 'Ask questions about books using multiple AI providers'
 AUTHOR = 'Sheldon'
 AUTHOR_EMAIL = 'sheldonrrr@gmail.com'
-KEYWORDS = 'bookAI readingAI multiAI OpenAI Anthropic Gemini DeepSeek Nvidia Ollama'
+KEYWORDS = 'bookAI readingAI multiAI OpenAI Anthropic Gemini DeepSeek Mistral Nvidia Ollama'
 
 logger = logging.getLogger(__name__)
 

--- a/ai_manager_dialog.py
+++ b/ai_manager_dialog.py
@@ -51,6 +51,7 @@ AI_PROVIDER_ORDER = [
     ('gemini', AIProvider.AI_GEMINI),
     ('grok', AIProvider.AI_GROK),
     ('deepseek', AIProvider.AI_DEEPSEEK),
+    ('mistral', AIProvider.AI_MISTRAL),
     ('nvidia', AIProvider.AI_NVIDIA),
     ('nvidia_free', AIProvider.AI_NVIDIA_FREE),  # 免费通道放在 Nvidia 后面
     ('perplexity', AIProvider.AI_PERPLEXITY),

--- a/aiprovider/mistral.md
+++ b/aiprovider/mistral.md
@@ -1,0 +1,46 @@
+# Mistral 配置指南
+
+Mistral 遵循 OpenAI 的 API 格式，配置相对直接。
+
+## 核心配置
+
+- **API Key**: 必需。在请求头中作为 Bearer Token 发送。
+- **Base URL**: 必需。官方地址为 `https://api.mistral.ai/v1`。
+
+## 获取模型列表
+
+- **端点**: `${baseUrl}/models`
+- **方法**: `GET`
+- **认证**:
+  ```json
+  {
+    "Authorization": "Bearer ${apiKey}"
+  }
+  ```
+
+## 发送聊天请求
+
+- **端点**: `${baseUrl}/chat/completions`
+- **方法**: `POST`
+- **认证**:
+  ```json
+  {
+    "Authorization": "Bearer ${apiKey}"
+  }
+  ```
+- **请求体 (Body)**:
+  ```json
+  {
+    "model": "mistral-large-latest",
+    "messages": [
+      {
+        "role": "user",
+        "content": "<用户提示词>"
+      }
+    ]
+  }
+  ```
+
+## 总结
+
+Mistral 是一个标准的 OpenAI 兼容 API，无需特殊处理。可在 https://console.mistral.ai/ 获取 API Key。

--- a/api.py
+++ b/api.py
@@ -40,6 +40,7 @@ class APIClient:
         'grok': AIProvider.AI_GROK,
         'gemini': AIProvider.AI_GEMINI,
         'deepseek': AIProvider.AI_DEEPSEEK,
+        'mistral': AIProvider.AI_MISTRAL,
         'custom': AIProvider.AI_CUSTOM,
         'openai': AIProvider.AI_OPENAI,
         'anthropic': AIProvider.AI_ANTHROPIC,

--- a/config.py
+++ b/config.py
@@ -13,6 +13,7 @@ from PyQt5.QtGui import QFontMetrics
 from .models.grok import GrokModel
 from .models.gemini import GeminiModel
 from .models.deepseek import DeepseekModel
+from .models.mistral import MistralModel
 from .models.custom import CustomModel
 from .models.openai import OpenAIModel
 from .models.anthropic import AnthropicModel
@@ -61,6 +62,7 @@ def get_current_model_config(provider: AIProvider) -> ModelConfig:
 GROK_CONFIG = get_current_model_config(AIProvider.AI_GROK)
 GEMINI_CONFIG = get_current_model_config(AIProvider.AI_GEMINI)
 DEEPSEEK_CONFIG = get_current_model_config(AIProvider.AI_DEEPSEEK)
+MISTRAL_CONFIG = get_current_model_config(AIProvider.AI_MISTRAL)
 CUSTOM_CONFIG = get_current_model_config(AIProvider.AI_CUSTOM)
 OPENAI_CONFIG = get_current_model_config(AIProvider.AI_OPENAI)
 ANTHROPIC_CONFIG = get_current_model_config(AIProvider.AI_ANTHROPIC)
@@ -71,7 +73,7 @@ PERPLEXITY_CONFIG = get_current_model_config(AIProvider.AI_PERPLEXITY)
 OLLAMA_CONFIG = get_current_model_config(AIProvider.AI_OLLAMA)
 
 AI_PROVIDER_ORDER = [
-    'openai', 'anthropic', 'gemini', 'grok', 'deepseek',
+    'openai', 'anthropic', 'gemini', 'grok', 'deepseek', 'mistral',
     'nvidia', 'nvidia_free', 'perplexity', 'openrouter', 'ollama', 'custom',
 ]
 
@@ -202,6 +204,14 @@ prefs.defaults['models'] = {
         'api_base_url': DEEPSEEK_CONFIG.default_api_base_url,
         'model': DEEPSEEK_CONFIG.default_model_name,
         'display_name': DEEPSEEK_CONFIG.display_name,        
+        'enabled': False  # 默认不启用，需要用户配置
+    },
+    'mistral': {
+        'api_key': '',
+        'api_base_url': MISTRAL_CONFIG.default_api_base_url,
+        'model': MISTRAL_CONFIG.default_model_name,
+        'display_name': MISTRAL_CONFIG.display_name,
+        'enable_streaming': True,
         'enabled': False  # 默认不启用，需要用户配置
     },
     'custom': {
@@ -591,6 +601,9 @@ class ModelConfigWidget(QWidget):
         elif self.model_id == 'deepseek':
             provider = AIProvider.AI_DEEPSEEK
             model_config = get_current_model_config(provider)
+        elif self.model_id == 'mistral':
+            provider = AIProvider.AI_MISTRAL
+            model_config = get_current_model_config(provider)
         elif self.model_id == 'custom':
             provider = AIProvider.AI_CUSTOM
             model_config = get_current_model_config(provider)
@@ -921,6 +934,10 @@ class ModelConfigWidget(QWidget):
             provider = AIProvider.AI_DEEPSEEK
             config['api_key'] = self.api_key_edit.toPlainText().strip() if hasattr(self, 'api_key_edit') else ''
             config['display_name'] = 'Deepseek'  # 设置固定的显示名称
+        elif self.model_id == 'mistral':
+            provider = AIProvider.AI_MISTRAL
+            config['api_key'] = self.api_key_edit.toPlainText().strip() if hasattr(self, 'api_key_edit') else ''
+            config['display_name'] = 'Mistral'  # 设置固定的显示名称
         elif self.model_id == 'custom':
             provider = AIProvider.AI_CUSTOM
             config['api_key'] = self.api_key_edit.toPlainText().strip() if hasattr(self, 'api_key_edit') else ''
@@ -1095,6 +1112,10 @@ class ModelConfigWidget(QWidget):
             default_model_name = model_config.default_model_name if model_config else None
         elif self.model_id == 'deepseek':
             provider = AIProvider.AI_DEEPSEEK
+            model_config = get_current_model_config(provider)
+            default_model_name = model_config.default_model_name if model_config else None
+        elif self.model_id == 'mistral':
+            provider = AIProvider.AI_MISTRAL
             model_config = get_current_model_config(provider)
             default_model_name = model_config.default_model_name if model_config else None
         elif self.model_id == 'openai':
@@ -1644,6 +1665,9 @@ class ModelConfigWidget(QWidget):
             elif self.model_id == 'deepseek':
                 from .models import DeepseekModel
                 model_config = DeepseekModel
+            elif self.model_id == 'mistral':
+                from .models import MistralModel
+                model_config = MistralModel
             elif self.model_id == 'custom':
                 from .models import CustomModel
                 model_config = CustomModel
@@ -1682,6 +1706,7 @@ class ModelConfigWidget(QWidget):
             'grok': AIProvider.AI_GROK,
             'gemini': AIProvider.AI_GEMINI,
             'deepseek': AIProvider.AI_DEEPSEEK,
+            'mistral': AIProvider.AI_MISTRAL,
             'custom': AIProvider.AI_CUSTOM,
             'openai': AIProvider.AI_OPENAI,
             'anthropic': AIProvider.AI_ANTHROPIC,
@@ -1746,6 +1771,8 @@ class ModelConfigWidget(QWidget):
             provider = AIProvider.AI_GEMINI
         elif self.model_id == 'deepseek':
             provider = AIProvider.AI_DEEPSEEK
+        elif self.model_id == 'mistral':
+            provider = AIProvider.AI_MISTRAL
         elif self.model_id == 'custom':
             provider = AIProvider.AI_CUSTOM
         elif self.model_id == 'openai':
@@ -1934,6 +1961,7 @@ class ConfigDialog(QWidget):
         AIModelFactory.register_model('grok', GrokModel)
         AIModelFactory.register_model('gemini', GeminiModel)
         AIModelFactory.register_model('deepseek', DeepseekModel)
+        AIModelFactory.register_model('mistral', MistralModel)
         AIModelFactory.register_model('custom', CustomModel)
         AIModelFactory.register_model('openai', OpenAIModel)
         AIModelFactory.register_model('anthropic', AnthropicModel)

--- a/i18n/da.py
+++ b/i18n/da.py
@@ -408,6 +408,7 @@ class DanishTranslation(BaseTranslation):
             'model_display_name_grok': 'Grok(x.AI)',
             'model_display_name_gemini': 'Gemini(Google)',
             'model_display_name_deepseek': 'Deepseek',
+            'model_display_name_mistral': 'Mistral',
             'model_display_name_custom': 'Brugerdefineret',
             'model_enable_streaming': 'Aktivér streaming',
 

--- a/i18n/de.py
+++ b/i18n/de.py
@@ -386,6 +386,7 @@ class GermanTranslation(BaseTranslation):
             'model_display_name_grok': 'Grok(x.AI)',
             'model_display_name_gemini': 'Gemini(Google)',
             'model_display_name_deepseek': 'Deepseek',
+            'model_display_name_mistral': 'Mistral',
             'model_display_name_custom': 'Benutzerdefiniert',
             'model_enable_streaming': 'Streaming aktivieren',
             

--- a/i18n/en.py
+++ b/i18n/en.py
@@ -413,6 +413,7 @@ class EnglishTranslation(BaseTranslation):
             'model_display_name_grok': 'Grok(x.AI)',
             'model_display_name_gemini': 'Gemini(Google)',
             'model_display_name_deepseek': 'Deepseek',
+            'model_display_name_mistral': 'Mistral',
             'model_display_name_custom': 'Custom',
             'model_enable_streaming': 'Enable Streaming',
             

--- a/i18n/es.py
+++ b/i18n/es.py
@@ -412,6 +412,7 @@ class SpanishTranslation(BaseTranslation):
             'model_display_name_grok': 'Grok(x.AI)',
             'model_display_name_gemini': 'Gemini(Google)',
             'model_display_name_deepseek': 'Deepseek',
+            'model_display_name_mistral': 'Mistral',
             'model_display_name_custom': 'Personalizado',
             'model_enable_streaming': 'Habilitar streaming',
             

--- a/i18n/fi.py
+++ b/i18n/fi.py
@@ -412,6 +412,7 @@ class FinnishTranslation(BaseTranslation):
             'model_display_name_grok': 'Grok(x.AI)',
             'model_display_name_gemini': 'Gemini(Google)',
             'model_display_name_deepseek': 'Deepseek',
+            'model_display_name_mistral': 'Mistral',
             'model_display_name_custom': 'Mukautettu',
             'model_enable_streaming': 'Ota suoratoisto käyttöön',
             

--- a/i18n/fr.py
+++ b/i18n/fr.py
@@ -426,6 +426,7 @@ class FrenchTranslation(BaseTranslation):
             'model_display_name_grok': 'Grok(x.AI)',
             'model_display_name_gemini': 'Gemini(Google)',
             'model_display_name_deepseek': 'Deepseek',
+            'model_display_name_mistral': 'Mistral',
             'model_display_name_custom': 'Personnalisé',
             'model_enable_streaming': 'Activer le streaming',
             

--- a/i18n/ja.py
+++ b/i18n/ja.py
@@ -415,6 +415,7 @@ class JapaneseTranslation(BaseTranslation):
             'model_display_name_grok': 'Grok(x.AI)',
             'model_display_name_gemini': 'Gemini(Google)',
             'model_display_name_deepseek': 'Deepseek',
+            'model_display_name_mistral': 'Mistral',
             'model_display_name_custom': 'カスタム',
             'model_enable_streaming': 'ストリーミングを有効にする',
             

--- a/i18n/nl.py
+++ b/i18n/nl.py
@@ -410,6 +410,7 @@ class DutchTranslation(BaseTranslation):
             'model_display_name_grok': 'Grok(x.AI)',
             'model_display_name_gemini': 'Gemini(Google)',
             'model_display_name_deepseek': 'Deepseek',
+            'model_display_name_mistral': 'Mistral',
             'model_display_name_custom': 'Aangepast',
             'model_enable_streaming': 'Streaming inschakelen',
 

--- a/i18n/no.py
+++ b/i18n/no.py
@@ -409,6 +409,7 @@ class NorwegianTranslation(BaseTranslation):
             'model_display_name_grok': 'Grok(x.AI)',
             'model_display_name_gemini': 'Gemini(Google)',
             'model_display_name_deepseek': 'Deepseek',
+            'model_display_name_mistral': 'Mistral',
             'model_display_name_custom': 'Egendefinert',
             'model_enable_streaming': 'Aktiver strømming',
 

--- a/i18n/pt.py
+++ b/i18n/pt.py
@@ -414,6 +414,7 @@ class PortugueseTranslation(BaseTranslation):
             'model_display_name_grok': 'Grok(x.AI)',
             'model_display_name_gemini': 'Gemini(Google)',
             'model_display_name_deepseek': 'Deepseek',
+            'model_display_name_mistral': 'Mistral',
             'model_display_name_custom': 'Personalizado',
             'model_enable_streaming': 'Ativar Streaming',
 

--- a/i18n/ru.py
+++ b/i18n/ru.py
@@ -410,6 +410,7 @@ class RussianTranslation(BaseTranslation):
             'model_display_name_grok': 'Grok(x.AI)',
             'model_display_name_gemini': 'Gemini(Google)',
             'model_display_name_deepseek': 'Deepseek',
+            'model_display_name_mistral': 'Mistral',
             'model_display_name_custom': 'Пользовательский',
             'model_enable_streaming': 'Включить стриминг',
 

--- a/i18n/sv.py
+++ b/i18n/sv.py
@@ -411,6 +411,7 @@ class SwedishTranslation(BaseTranslation):
             'model_display_name_grok': 'Grok(x.AI)',
             'model_display_name_gemini': 'Gemini(Google)',
             'model_display_name_deepseek': 'Deepseek',
+            'model_display_name_mistral': 'Mistral',
             'model_display_name_custom': 'Anpassad',
             'model_enable_streaming': 'Aktivera strömning',
 

--- a/i18n/yue.py
+++ b/i18n/yue.py
@@ -388,6 +388,7 @@ class CantoneseTranslation(BaseTranslation):
             'model_display_name_grok': 'Grok(x.AI)', # Grok(x.AI)
             'model_display_name_gemini': 'Gemini(Google)', # Gemini(Google)
             'model_display_name_deepseek': 'Deepseek', # Deepseek
+            'model_display_name_mistral': 'Mistral', # Mistral
             'model_display_name_custom': '自訂', # Custom
             'model_enable_streaming': '啟用串流', # Enable Streaming
 

--- a/i18n/zh.py
+++ b/i18n/zh.py
@@ -408,6 +408,7 @@ class SimplifiedChineseTranslation(BaseTranslation):
             'model_display_name_grok': 'Grok(x.AI)',
             'model_display_name_gemini': 'Gemini(Google)',
             'model_display_name_deepseek': 'Deepseek',
+            'model_display_name_mistral': 'Mistral',
             'model_display_name_custom': '自定义',
             'model_enable_streaming': '启用流式传输',
             

--- a/i18n/zht.py
+++ b/i18n/zht.py
@@ -409,6 +409,7 @@ class TraditionalChineseTranslation(BaseTranslation):
         'model_display_name_grok': 'Grok(x.AI)',
         'model_display_name_gemini': 'Gemini(Google)',
         'model_display_name_deepseek': 'Deepseek',
+        'model_display_name_mistral': 'Mistral',
         'model_display_name_custom': '自定義',
         'model_enable_streaming': '啟用串流傳輸',
         

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -8,6 +8,7 @@ from .base import BaseAIModel, AIModelFactory
 from .grok import GrokModel
 from .gemini import GeminiModel
 from .deepseek import DeepseekModel
+from .mistral import MistralModel
 from .custom import CustomModel
 from .openai import OpenAIModel
 from .anthropic import AnthropicModel
@@ -21,6 +22,7 @@ from .ollama import OllamaModel
 AIModelFactory.register_model('grok', GrokModel)
 AIModelFactory.register_model('gemini', GeminiModel)
 AIModelFactory.register_model('deepseek', DeepseekModel)
+AIModelFactory.register_model('mistral', MistralModel)
 AIModelFactory.register_model('custom', CustomModel)
 AIModelFactory.register_model('openai', OpenAIModel)
 AIModelFactory.register_model('anthropic', AnthropicModel)
@@ -31,4 +33,4 @@ AIModelFactory.register_model('perplexity', PerplexityModel)
 AIModelFactory.register_model('ollama', OllamaModel)
 
 # 导出公共接口
-__all__ = ['BaseAIModel', 'AIModelFactory', 'GrokModel', 'GeminiModel', 'DeepseekModel', 'CustomModel', 'OpenAIModel', 'AnthropicModel', 'NvidiaModel', 'NvidiaFreeModel', 'OpenRouterModel', 'PerplexityModel', 'OllamaModel']
+__all__ = ['BaseAIModel', 'AIModelFactory', 'GrokModel', 'GeminiModel', 'DeepseekModel', 'MistralModel', 'CustomModel', 'OpenAIModel', 'AnthropicModel', 'NvidiaModel', 'NvidiaFreeModel', 'OpenRouterModel', 'PerplexityModel', 'OllamaModel']

--- a/models/base.py
+++ b/models/base.py
@@ -13,6 +13,7 @@ class AIProvider(Enum):
     AI_GROK = auto()      # x.AI (Grok)
     AI_GEMINI = auto()    # Google Gemini
     AI_DEEPSEEK = auto()  # Deepseek
+    AI_MISTRAL = auto()   # Mistral AI
     AI_CUSTOM = auto()    # Custom (Local or Remote API)
     AI_OPENAI = auto()    # OpenAI (GPT models)
     AI_ANTHROPIC = auto() # Anthropic (Claude models)
@@ -70,6 +71,13 @@ DEFAULT_MODELS = {
         api_key_label="API Key:",
         default_api_base_url="https://api.deepseek.com",
         default_model_name="deepseek-v4-flash"
+    ),
+    AIProvider.AI_MISTRAL: ModelConfig(
+        provider=AIProvider.AI_MISTRAL,
+        display_name="Mistral",
+        api_key_label="Mistral API Key:",
+        default_api_base_url="https://api.mistral.ai/v1",
+        default_model_name="mistral-large-latest"
     ),
     AIProvider.AI_CUSTOM: ModelConfig(
         provider=AIProvider.AI_CUSTOM,

--- a/models/mistral.py
+++ b/models/mistral.py
@@ -1,0 +1,323 @@
+"""
+Mistral AI Model Implementation
+
+Mistral API is OpenAI Chat Completions compatible.
+Base URL: https://api.mistral.ai/v1
+"""
+import json
+import time
+import logging
+from typing import Dict, Any
+
+# 从 vendor 命名空间导入第三方库
+from calibre_plugins.ask_ai_plugin.lib.ask_ai_plugin_vendor import requests
+
+from .base import BaseAIModel
+from ..i18n import get_translation
+
+
+class MistralModel(BaseAIModel):
+    """
+    Mistral AI Model Implementation Class
+    """
+    # Default model name
+    DEFAULT_MODEL = "mistral-large-latest"
+    # Default API base URL
+    DEFAULT_API_BASE_URL = "https://api.mistral.ai/v1"
+
+    def _validate_config(self):
+        """
+        Validate Mistral model configuration
+
+        :raises ValueError: When configuration is invalid
+        """
+        required_keys = ['api_key', 'api_base_url']
+        for key in required_keys:
+            if not self.config.get(key):
+                translations = get_translation(self.config.get('language', 'en'))
+                raise ValueError(
+                    translations.get(
+                        'missing_required_config',
+                        'Missing required configuration: {key}',
+                    ).format(key=key)
+                )
+
+        if not self.config.get('model'):
+            self.config['model'] = self.DEFAULT_MODEL
+
+    def get_token(self) -> str:
+        """
+        Get Mistral API Key
+
+        :return: API Key string
+        """
+        return self.config.get('api_key', '')
+
+    def validate_token(self) -> bool:
+        """
+        Validate if Mistral API Key is present
+
+        :return: True if token is valid
+        :raises ValueError: When token is invalid
+        """
+        super().validate_token()
+
+        token = self.get_token()
+        if not token or token.strip() == '':
+            translations = get_translation(self.config.get('language', 'en'))
+            raise ValueError(
+                translations.get(
+                    'api_key_empty',
+                    'API Key is empty. Please enter a valid API Key.',
+                )
+            )
+
+        if len(token.strip()) < 10:
+            translations = get_translation(self.config.get('language', 'en'))
+            raise ValueError(
+                translations.get(
+                    'api_key_too_short',
+                    'API Key is too short. Please check and enter the complete key.',
+                )
+            )
+
+        return True
+
+    def prepare_headers(self) -> Dict[str, str]:
+        """
+        Prepare Mistral API request headers
+
+        :return: Request headers dictionary
+        """
+        token = self.get_token()
+
+        if not token.startswith('Bearer '):
+            token = f'Bearer {token}'
+
+        return {
+            "Content-Type": "application/json",
+            "Authorization": token,
+        }
+
+    def prepare_request_data(self, prompt: str, **kwargs) -> Dict[str, Any]:
+        """
+        Prepare Mistral API request data
+
+        :param prompt: Prompt text
+        :param kwargs: Other parameters like temperature, stream, etc.
+        :return: Request data dictionary
+        """
+        translations = get_translation(self.config.get('language', 'en'))
+        system_message = kwargs.get(
+            'system_message',
+            translations.get(
+                'default_system_message',
+                'You are an expert in book analysis. Your task is to help users understand books better by providing insightful questions and analysis.',
+            ),
+        )
+
+        data = {
+            "model": self.config.get('model', self.DEFAULT_MODEL),
+            "messages": [
+                {
+                    "role": "system",
+                    "content": system_message,
+                },
+                {
+                    "role": "user",
+                    "content": prompt,
+                },
+            ],
+            "temperature": kwargs.get('temperature', 0.7),
+            "max_tokens": kwargs.get('max_tokens', 4096),
+        }
+
+        if kwargs.get('stream', False):
+            data['stream'] = True
+
+        return data
+
+    def ask(self, prompt: str, **kwargs) -> str:
+        """
+        Send prompt to Mistral API and get response
+
+        :param prompt: Prompt text
+        :param kwargs: Other parameters like temperature, stream, stream_callback, etc.
+        :return: AI model response text
+        :raises Exception: When request fails
+        """
+        headers = self.prepare_headers()
+        data = self.prepare_request_data(prompt, **kwargs)
+
+        use_stream = kwargs.get('stream', self.config.get('enable_streaming', True))
+        stream_callback = kwargs.get('stream_callback', None)
+        logger = logging.getLogger('calibre_plugins.ask_ai_plugin.models.mistral')
+
+        try:
+            if use_stream and stream_callback:
+                full_content = ""
+                chunk_count = 0
+                last_chunk_time = time.time()
+
+                api_url = f"{self.config['api_base_url']}/chat/completions"
+
+                try:
+                    with requests.post(
+                        api_url,
+                        headers=headers,
+                        json=data,
+                        timeout=kwargs.get('timeout', 300),
+                        stream=True,
+                    ) as response:
+                        response.raise_for_status()
+
+                        for line in response.iter_lines():
+                            if line:
+                                line_str = line.decode('utf-8')
+                                if line_str.startswith('data: '):
+                                    try:
+                                        if line_str == 'data: [DONE]':
+                                            break
+                                        line_data = json.loads(line_str[6:])
+                                        if 'choices' in line_data and line_data['choices']:
+                                            choice = line_data['choices'][0]
+                                            if 'delta' in choice and 'content' in choice['delta']:
+                                                chunk_text = choice['delta']['content']
+                                                if chunk_text:
+                                                    full_content += chunk_text
+                                                    stream_callback(chunk_text)
+                                                    chunk_count += 1
+                                                    last_chunk_time = time.time()
+                                    except json.JSONDecodeError as je:
+                                        logger.error(
+                                            f"JSON parse error: {str(je)}, line content: {line_str[:50]}..."
+                                        )
+                                        continue
+
+                                current_time = time.time()
+                                if current_time - last_chunk_time > 15:
+                                    logger.warning(
+                                        f"No new data received for {current_time - last_chunk_time:.1f} seconds"
+                                    )
+
+                                if current_time - last_chunk_time > 60 and full_content:
+                                    logger.warning(
+                                        "No response for over 60 seconds, triggering recovery mechanism"
+                                    )
+                                    translations = get_translation(
+                                        self.config.get('language', 'en')
+                                    )
+                                    raise requests.exceptions.ReadTimeout(
+                                        translations.get(
+                                            'stream_timeout_error',
+                                            "Streaming timeout after 60 seconds with no new content, possible connection issue",
+                                        )
+                                    )
+
+                        logger.info(
+                            f"Streaming completed, received {chunk_count} chunks, total length: {len(full_content)}"
+                        )
+                        return full_content
+
+                except requests.exceptions.RequestException as e:
+                    logger.error(f"Mistral API request error: {str(e)}")
+                    translations = get_translation(self.config.get('language', 'en'))
+                    raise Exception(
+                        translations.get(
+                            'api_request_failed',
+                            'API request failed: {error}',
+                        ).format(error=str(e))
+                    )
+
+            else:
+                api_url = f"{self.config['api_base_url']}/chat/completions"
+                response = requests.post(
+                    api_url,
+                    headers=headers,
+                    json=data,
+                    timeout=kwargs.get('timeout', 60),
+                )
+                response.raise_for_status()
+
+                result = response.json()
+                if 'choices' in result and result['choices']:
+                    return result['choices'][0]['message']['content']
+                else:
+                    translations = get_translation(self.config.get('language', 'en'))
+                    raise Exception(
+                        translations.get(
+                            'invalid_response',
+                            'Invalid API response format',
+                        )
+                    )
+
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Mistral API request error: {str(e)}")
+            translations = get_translation(self.config.get('language', 'en'))
+            raise Exception(
+                translations.get(
+                    'api_request_failed',
+                    'API request failed: {error}',
+                ).format(error=str(e))
+            )
+
+    def send_message(self, prompt: str, callback: callable) -> None:
+        """
+        Send message and stream response via callback
+
+        :param prompt: Prompt text
+        :param callback: Callback function to receive streaming text
+        """
+        try:
+            self.ask(prompt, stream=True, stream_callback=callback)
+        except Exception as e:
+            logger = logging.getLogger('calibre_plugins.ask_ai_plugin.models.mistral')
+            logger.error(f"send_message error: {str(e)}")
+            raise
+
+    def stop_stream(self) -> None:
+        """
+        Stop streaming response
+        Note: Current implementation does not support mid-stream interruption
+        """
+        pass
+
+    def get_model_name(self) -> str:
+        """
+        Get current model name
+
+        :return: Model name string
+        """
+        return self.config.get('model', self.DEFAULT_MODEL)
+
+    def get_provider_name(self) -> str:
+        """
+        Get provider name
+
+        :return: Provider name string
+        """
+        return "Mistral"
+
+    def supports_streaming(self) -> bool:
+        """
+        Check if model supports streaming
+
+        :return: True if streaming is supported
+        """
+        return True
+
+    @classmethod
+    def get_default_config(cls) -> Dict[str, Any]:
+        """
+        Get Mistral model default configuration
+
+        :return: Default configuration dictionary
+        """
+        return {
+            "api_key": "",
+            "api_base_url": cls.DEFAULT_API_BASE_URL,
+            "model": cls.DEFAULT_MODEL,
+            "enable_streaming": True,
+        }
+
+    # Mistral 使用基类的默认实现，无需重写 fetch_available_models

--- a/qa_actions.py
+++ b/qa_actions.py
@@ -36,6 +36,7 @@ def get_ai_display_name(ai_name):
         'grok': 'Grok',
         'gemini': 'Gemini',
         'deepseek': 'DeepSeek',
+        'mistral': 'Mistral',
         'anthropic': 'Claude',
         'nvidia': 'Nvidia',
         'openrouter': 'OpenRouter',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds first-class **Mistral** provider support so users can configure a Mistral API Key and send chat requests without using the Custom provider workaround.

## Changes

- New `models/mistral.py`: OpenAI-compatible client with Bearer `api_key`, streaming/non-streaming `chat/completions`
- Defaults: base URL `https://api.mistral.ai/v1`, model `mistral-large-latest`, `api_key_label`: `Mistral API Key:`
- Registered across factory, API client, Add AI dialog, config UI, and `qa_actions` display names (`provider_id`: `mistral`)
- i18n `model_display_name_mistral` for all languages; docs in `aiprovider/mistral.md` and README

## Test plan

- [x] `python3 -m unittest tests.test_i18n_parity -v`
- [x] Static wiring check for `mistral` registration in `config.py` / `api.py` / `ai_manager_dialog.py` / `models/__init__.py`
- [ ] In calibre: Add AI → Mistral → enter API Key → refresh models → save → ask a book question

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f77e2-e367-7ddc-b566-0656e4060a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f77e2-e367-7ddc-b566-0656e4060a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

