### PR TITLE
Update Gemini client to the latest REST request format

### DIFF
--- a/aiprovider/gemini.md
+++ b/aiprovider/gemini.md
@@ -2,119 +2,107 @@
 
 ## 核心配置
 
-- **API Key**: 必需。作为 URL 查询参数发送。
-- **Base URL**: 必需。这是 API 的根地址，例如 `https://generativelanguage.googleapis.com/v1beta`。
+- **API Key**: 必需。通过请求头 `x-goog-api-key` 发送（推荐；旧的 `?key=` 查询参数仍可用但不推荐）。
+- **Base URL**: 必需。例如 `https://generativelanguage.googleapis.com/v1beta`。
+- **Model**: 使用 Google AI 原生名称，例如 `gemini-3.5-flash`（不要使用 OpenRouter 风格的 `google/gemini-...`）。
 
 ## 获取模型列表
 
 ### REST API 方式
-- **完整 URL**: `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}`
-- **端点**: `/v1beta/models`
+- **URL**: `https://generativelanguage.googleapis.com/v1beta/models`
 - **方法**: `GET`
-- **认证**: API Key 作为 URL 查询参数 `key` 传递
+- **认证**:
+  ```http
+  x-goog-api-key: ${apiKey}
+  ```
+- **请求头**: GET 请求不要带 `Content-Type`
 - **响应格式**:
   ```json
   {
     "models": [
       {
-        "name": "models/gemini-2.5-flash",
-        "displayName": "Gemini 2.5 Flash",
-        "supportedActions": ["generateContent", "embedContent"]
+        "name": "models/gemini-3.5-flash",
+        "displayName": "Gemini 3.5 Flash",
+        "supportedGenerationMethods": ["generateContent", "countTokens"]
       }
     ]
   }
   ```
 - **注意事项**:
-  1. 响应中的模型名称包含 `models/` 前缀，需要移除后使用
-  2. 可以通过 `supportedActions` 字段过滤支持特定功能的模型
-  3. 只返回支持 `generateContent` 的模型用于对话
-
-### Python SDK 方式（参考）
-```python
-from google import genai
-
-client = genai.Client()
-
-# 列出支持 generateContent 的模型
-print("List of models that support generateContent:\n")
-for m in client.models.list():
-    for action in m.supported_actions:
-        if action == "generateContent":
-            print(m.name)
-
-# 列出支持 embedContent 的模型
-print("List of models that support embedContent:\n")
-for m in client.models.list():
-    for action in m.supported_actions:
-        if action == "embedContent":
-            print(m.name)
-```
+  1. 响应中的模型名称包含 `models/` 前缀，使用前需要移除
+  2. 建议只保留 `supportedGenerationMethods` 包含 `generateContent` 的模型
 
 ## 发送聊天请求
 
-- **端点**: `${baseUrl}/${model_name}:generateContent?key=${apiKey}`
+- **端点**: `${baseUrl}/models/${model_name}:generateContent`
+- **流式端点**: `${baseUrl}/models/${model_name}:streamGenerateContent?alt=sse`
 - **方法**: `POST`
-- **认证**: API Key 同样附加在 URL 的查询参数中。
+- **认证**:
+  ```http
+  x-goog-api-key: ${apiKey}
+  Content-Type: application/json
+  ```
 - **请求体 (Body)**:
   ```json
   {
+    "systemInstruction": {
+      "parts": [
+        {
+          "text": "<系统提示词>"
+        }
+      ]
+    },
     "contents": [
       {
+        "role": "user",
         "parts": [
           {
             "text": "<用户提示词>"
           }
         ]
       }
-    ]
+    ],
+    "generationConfig": {
+      "temperature": 0.7
+    }
   }
   ```
 
 ## 实现要点
 
-### 获取模型列表的特殊处理
-1. **认证方式**: API Key 必须作为 URL 查询参数 `key` 传递，不能放在请求头中
-2. **请求头**: GET 请求不应包含 `Content-Type` 头，否则可能导致 400 错误
-3. **响应处理**: 模型名称包含 `models/` 前缀（如 `models/gemini-2.5-flash`），使用时需要移除前缀
-4. **模型过滤**: 建议只返回 `supportedActions` 包含 `generateContent` 的模型
+1. **认证**: 优先使用 `x-goog-api-key` 请求头，不要把 Key 放进 URL
+2. **系统提示**: 使用顶层字段 `systemInstruction`，不要再伪装成 `role: user` 的 contents
+3. **模型名**: URL 中使用 `gemini-3.5-flash`，不要带 `models/`；也不要带 `google/`
+4. **流式**: `streamGenerateContent` + `alt=sse`，按 `data: {...}` 解析 `candidates[0].content.parts[].text`
 
-### 常见问题
+## 常见问题
 
-#### 400 Bad Request 错误
-**原因**: 
-- GET 请求包含了不必要的 `Content-Type: application/json` 头
-- API Key 格式错误或包含特殊字符未正确编码
+### 404 Not Found
+**原因**: 模型名错误（例如误用 `google/gemini-3.5-flash`）
 
 **解决方案**:
-- 移除 GET 请求的 Content-Type 头
-- 确保 API Key 正确 URL 编码
+- 改成 `gemini-3.5-flash`
+- 或在设置里刷新模型列表后重新选择
 
-#### 400 Bad Request - 地理位置限制
+### 400 Bad Request - 地理位置限制
 **错误信息**: `User location is not supported for the API use.`
 
-**原因**: Gemini API 在某些地区不可用（如中国大陆）
-
 **解决方案**:
-1. **使用 VPN**: 连接到支持的地区（如美国、欧洲等）
-2. **切换提供商**: 使用其他 AI 提供商
-   - OpenAI (GPT-4)
-   - Anthropic (Claude)
-   - DeepSeek
-   - Nvidia AI
-   - Ollama (本地运行)
-3. **查看可用性**: 访问 [Google AI Studio](https://aistudio.google.com/) 查看您所在地区的可用性
+1. 使用 VPN 连接到支持地区
+2. 切换到其他 AI 提供商
+3. 在 [Google AI Studio](https://aistudio.google.com/) 查看地区可用性
 
-#### 401 Unauthorized 错误
-**原因**: API Key 无效或已过期
+### 401 / 403 Unauthorized
+**原因**: API Key 无效或权限不足
 
 **解决方案**:
 - 在 Google AI Studio 重新生成 API Key
-- 确认 API Key 已启用 Gemini API 访问权限
+- 确认 Key 已启用 Gemini API 访问
 
 ## 总结
 
-Gemini 的 API 设计比较独特：
-1. **认证方式**: API Key 通过 URL 参数传递，而非请求头
-2. **端点格式**: 聊天请求需要动态拼接模型名称，格式为 `${model_name}:generateContent`
-3. **模型名称**: 响应中的模型名称包含 `models/` 前缀，需要移除
-4. **请求头**: GET 请求（如获取模型列表）不需要 Content-Type 头
+最新 Gemini REST 请求格式的关键点：
+1. Header 认证：`x-goog-api-key`
+2. 系统提示：`systemInstruction`
+3. 对话内容：`contents[].role` + `parts[].text`
+4. 模型名：原生 ID（如 `gemini-3.5-flash`）

--- a/models/base.py
+++ b/models/base.py
@@ -62,7 +62,7 @@ DEFAULT_MODELS = {
         display_name="Google Gemini",
         api_key_label="API Key:",
         default_api_base_url="https://generativelanguage.googleapis.com/v1beta",
-        default_model_name="google/gemini-3.5-flash"
+        default_model_name="gemini-3.5-flash"
     ),
     AIProvider.AI_DEEPSEEK: ModelConfig(
         provider=AIProvider.AI_DEEPSEEK,

--- a/models/gemini.py
+++ b/models/gemini.py
@@ -1,10 +1,16 @@
 """
 Google Gemini 模型实现
+
+使用最新 Gemini REST API 格式：
+- Auth: x-goog-api-key header
+- Endpoint: /v1beta/models/{model}:generateContent
+- System prompt: systemInstruction
+- Streaming: :streamGenerateContent?alt=sse
 """
 import json
 import re
 import time
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 import logging
 
 # 从 vendor 命名空间导入第三方库
@@ -16,156 +22,199 @@ from ..i18n import get_translation
 # 获取日志记录器
 logger = logging.getLogger('calibre_plugins.ask_ai_plugin.models.gemini')
 
+
 class GeminiModel(BaseAIModel):
     """
     Google Gemini 模型实现类
     """
-    # 默认模型名称，集中管理便于后续更新
-    DEFAULT_MODEL = "google/gemini-3.5-flash"
+    # 默认模型名称（Google AI Studio / generativelanguage API 格式，不含 google/ 前缀）
+    DEFAULT_MODEL = "gemini-3.5-flash"
     # 默认 API 基础 URL
     DEFAULT_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
-    
+
     def _validate_config(self):
         """
         验证 Gemini 模型配置
-        
+
         :raises ValueError: 当配置无效时抛出异常
         """
-        # 基本必需字段（不包括 model，因为在获取模型列表时可能为空）
         required_keys = ['api_key']
         for key in required_keys:
             if not self.config.get(key):
                 translations = get_translation(self.config.get('language', 'en'))
-                raise ValueError(translations.get('missing_required_config', 'Missing required configuration: {key}').format(key=key))
-        
-        # 确保 api_base_url 存在，如果不存在则使用默认值
-        if 'api_base_url' not in self.config:
+                raise ValueError(
+                    translations.get(
+                        'missing_required_config',
+                        'Missing required configuration: {key}',
+                    ).format(key=key)
+                )
+
+        if 'api_base_url' not in self.config or not self.config.get('api_base_url'):
             self.config['api_base_url'] = self.DEFAULT_API_BASE_URL
-        
-        # 如果 model 为空，使用默认值
+
         if not self.config.get('model'):
             self.config['model'] = self.DEFAULT_MODEL
-    
+
     def get_token(self) -> str:
         """
         获取 Gemini 模型的 API Key/Token
-        
+
         :return: API Key/Token 字符串
         """
         return self.config.get('api_key', '')
-    
+
     def validate_token(self) -> bool:
         """
         验证 Gemini 模型的 token 是否有效
-        
+
         :return: 如果 token 有效则返回 True
         :raises ValueError: 当 token 无效时抛出异常
         """
-        # 首先调用基类的基本验证
         super().validate_token()
-        
-        # 只进行基本的长度检查
+
         token = self.get_token()
-        if len(token) < 10:  # 只要求基本长度
+        if len(token) < 10:
             translations = get_translation(self.config.get('language', 'en'))
-            raise ValueError(translations.get('api_key_too_short', 'API Key is too short. Please check and enter the complete key.'))
-        
+            raise ValueError(
+                translations.get(
+                    'api_key_too_short',
+                    'API Key is too short. Please check and enter the complete key.',
+                )
+            )
+
         return True
-    
+
     def prepare_headers(self) -> Dict[str, str]:
         """
-        准备 Gemini API 请求头
-        
+        准备 Gemini API 请求头（最新推荐：x-goog-api-key）
+
         :return: 请求头字典
         """
         headers = {
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
-        
-        # 在这里直接添加 API Key，而不是在 ask 方法中
+
         api_key = self.get_token()
         if api_key:
             headers["x-goog-api-key"] = api_key
-            
+
         return headers
-    
+
+    @staticmethod
+    def normalize_model_name(model_name: str, default: str = None) -> str:
+        """
+        规范化模型名，兼容历史配置中的 models/ 与 google/ 前缀。
+
+        :param model_name: 原始模型名
+        :param default: 为空时的默认值
+        :return: 可用于 URL 的模型名，如 gemini-3.5-flash
+        """
+        name = (model_name or '').strip()
+        if not name:
+            return default or GeminiModel.DEFAULT_MODEL
+
+        if name.startswith('models/'):
+            name = name[len('models/'):]
+
+        # OpenRouter 风格前缀，不能用于 generativelanguage.googleapis.com
+        if name.startswith('google/'):
+            name = name[len('google/'):]
+
+        return name
+
     def prepare_request_data(self, prompt: str, **kwargs) -> Dict[str, Any]:
         """
-        准备 Gemini API 请求数据
-        
+        准备 Gemini API 请求数据（使用 systemInstruction + contents）
+
         :param prompt: 提示文本
         :param kwargs: 其他参数，如 temperature 等
         :return: 请求数据字典
         """
         translations = get_translation(self.config.get('language', 'en'))
-        system_message = kwargs.get('system_message', translations.get('default_system_message', 'You are an expert in book analysis. Your task is to help users understand books better by providing insightful questions and analysis.'))
-        
-        # 构建基本请求数据结构，严格按照 Gemini API 要求格式化
-        data = {
-            "contents": []
+        system_message = kwargs.get(
+            'system_message',
+            translations.get(
+                'default_system_message',
+                'You are an expert in book analysis. Your task is to help users understand books better by providing insightful questions and analysis.',
+            ),
+        )
+
+        data: Dict[str, Any] = {
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"text": prompt}
+                    ],
+                }
+            ]
         }
-        
-        # 如果有系统消息，添加为第一条消息
+
+        # 最新格式：系统提示使用 systemInstruction，而不是伪装成 user 消息
         if system_message and system_message.strip():
-            data["contents"].append({
-                "role": "user",  # Gemini 2.5 支持 role，但使用 user 而非 system
+            data["systemInstruction"] = {
                 "parts": [
                     {"text": system_message}
                 ]
-            })
-        
-        # 添加用户提示
-        data["contents"].append({
-            "role": "user",  # 明确指定角色
-            "parts": [
-                {"text": prompt}
-            ]
-        })
-        
-        # 添加生成配置
-        generation_config = {}
-        
-        # 温度参数
-        if 'temperature' in kwargs:
-            generation_config["temperature"] = kwargs.get('temperature')
-        
-        # 最大输出令牌数 (如果用户指定了，则覆盖默认值)
-        if 'max_tokens' in kwargs:
-            generation_config["maxOutputTokens"] = kwargs.get('max_tokens')
-        
-        # 最大输出令牌数为 128000
-        generation_config["maxOutputTokens"] = 128000
+            }
 
-        # 采样参数
-        if 'top_p' in kwargs:
+        generation_config: Dict[str, Any] = {}
+
+        temperature = kwargs.get('temperature', 0.7)
+        if temperature is not None:
+            generation_config["temperature"] = temperature
+
+        if 'max_tokens' in kwargs and kwargs.get('max_tokens') is not None:
+            generation_config["maxOutputTokens"] = kwargs.get('max_tokens')
+
+        if 'top_p' in kwargs and kwargs.get('top_p') is not None:
             generation_config["topP"] = kwargs.get('top_p')
-        
-        if 'top_k' in kwargs:
+
+        if 'top_k' in kwargs and kwargs.get('top_k') is not None:
             generation_config["topK"] = kwargs.get('top_k')
-        
-        # 添加生成配置 (现在总是会添加，因为我们有默认的 maxOutputTokens)
-        data['generationConfig'] = generation_config
-            
+
+        if generation_config:
+            data['generationConfig'] = generation_config
+
         return data
-    
+
     def mask_api_key(self, text: str) -> str:
         """
         隐藏文本中的 API Key
-        
+
         :param text: 原始文本
         :return: 隐藏 API Key 后的文本
         """
-        # 隐藏 URL 参数中的 API Key
         text = re.sub(r'key=[A-Za-z0-9_-]+', 'key=********', text)
-        
-        # 隐藏 JSON 中的 API Key
         text = re.sub(r'"api_key"\s*:\s*"[^"]+"', '"api_key":"********"', text)
-        
+        text = re.sub(
+            r'(?i)(x-goog-api-key["\']?\s*[:=]\s*["\']?)[^"\'\s,]+',
+            r'\1********',
+            text,
+        )
         return text
-    
+
+    def _build_generate_url(self, model_name: str, api_base_url: str, use_stream: bool) -> str:
+        """构建 generateContent / streamGenerateContent URL。"""
+        base = (api_base_url or self.DEFAULT_API_BASE_URL).rstrip('/')
+        model = self.normalize_model_name(model_name, self.DEFAULT_MODEL)
+        action = "streamGenerateContent" if use_stream else "generateContent"
+        return f"{base}/models/{model}:{action}"
+
+    def _extract_text_from_candidate(self, candidate: Dict[str, Any]) -> str:
+        """从 candidate.content.parts 提取文本。"""
+        content = candidate.get('content') or {}
+        parts = content.get('parts') or []
+        texts = []
+        for part in parts:
+            text = part.get('text')
+            if text:
+                texts.append(text)
+        return ''.join(texts)
+
     def ask(self, prompt: str, **kwargs) -> str:
         """向 Gemini API 发送请求并获取回复
-        
+
         Args:
             prompt: 用户提问
             **kwargs: 其他参数，包括：
@@ -176,418 +225,443 @@ class GeminiModel(BaseAIModel):
                 top_k: Top-k 采样
                 stream: 是否使用流式传输
                 stream_callback: 流式回调函数
-                
+
         Returns:
             模型回复的文本
         """
-        # 获取模型名称和API基础URL
-        model_name = kwargs.get('model', self.DEFAULT_MODEL)
-        api_base_url = kwargs.get('api_base_url', self.DEFAULT_API_BASE_URL)
-        
-        # 准备请求头和请求体
+        model_name = kwargs.get('model') or self.config.get('model', self.DEFAULT_MODEL)
+        api_base_url = kwargs.get('api_base_url') or self.config.get(
+            'api_base_url', self.DEFAULT_API_BASE_URL
+        )
+
         headers = self.prepare_headers()
         data = self.prepare_request_data(prompt, **kwargs)
-        
-        # 获取流式传输设置（只有明确指定才使用流式）
-        use_stream = kwargs.get('stream', False)
+
+        use_stream = kwargs.get('stream', self.config.get('enable_streaming', True))
         stream_callback = kwargs.get('stream_callback', None)
-        
-        # 根据是否使用流式传输构建不同的URL
+
         params = {}
-        if use_stream:
-            url = f"{api_base_url}/models/{model_name}:streamGenerateContent"
-            params["alt"] = "sse"  # 使用 Server-Sent Events 格式
-        else:
-            url = f"{api_base_url}/models/{model_name}:generateContent"
-            params = {}
-        
-        
-        # 重试设置
+        url = self._build_generate_url(model_name, api_base_url, use_stream and bool(stream_callback))
+        if use_stream and stream_callback:
+            params["alt"] = "sse"
+
         max_retries = 3
-        retry_delay = 2  # 秒
-        
+        retry_delay = 2
+
         for attempt in range(max_retries):
             try:
                 if use_stream and stream_callback:
-                    # 流式请求处理
                     full_content = ""
                     chunk_count = 0
                     last_chunk_time = time.time()
-                    
-                    # 增加超时时间到 300 秒，避免长回复时请求超时
+
                     with requests.post(
                         url,
                         headers=headers,
                         json=data,
                         params=params,
-                        timeout=kwargs.get('timeout', 300),  # 增加默认超时时间到 300 秒
-                        stream=True
+                        timeout=kwargs.get('timeout', 300),
+                        stream=True,
                     ) as response:
                         response.raise_for_status()
-                        
+
                         try:
                             for line in response.iter_lines():
                                 if line:
                                     line = line.decode('utf-8')
-                                    
-                                    # 处理 SSE 格式，必须以 'data: ' 开头
+
                                     if line.startswith('data: '):
-                                        line = line[6:]  # 去除 'data: ' 前缀
-                                        
-                                        # 特殊情况处理：如果是 [DONE] 标记
+                                        line = line[6:]
+
                                         if line.strip() == "[DONE]":
                                             break
-                                        
+
                                         try:
                                             chunk_data = json.loads(line)
-                                            
-                                            # 解析 Gemini 流式响应格式
+
                                             if 'candidates' in chunk_data and chunk_data['candidates']:
                                                 candidate = chunk_data['candidates'][0]
-                                                if 'content' in candidate:
-                                                    content = candidate['content']
-                                                    if 'parts' in content and content['parts']:
-                                                        for part in content['parts']:
-                                                            if 'text' in part and part['text']:
-                                                                chunk_text = part['text']
-                                                                full_content += chunk_text
-                                                                stream_callback(chunk_text)
-                                                                chunk_count += 1
-                                                                last_chunk_time = time.time()
+                                                chunk_text = self._extract_text_from_candidate(candidate)
+                                                if chunk_text:
+                                                    full_content += chunk_text
+                                                    stream_callback(chunk_text)
+                                                    chunk_count += 1
+                                                    last_chunk_time = time.time()
                                         except json.JSONDecodeError as je:
-                                            logger.error(f"JSON解析错误: {str(je)}, 行内容: {line[:50]}...")
+                                            logger.error(
+                                                f"JSON解析错误: {str(je)}, 行内容: {line[:50]}..."
+                                            )
                                             continue
-                                
-                                # 检查是否超过5秒没有收到新数据
+
                                 current_time = time.time()
                                 if current_time - last_chunk_time > 15:
-                                    logger.warning(f"已经 {current_time - last_chunk_time:.1f} 秒没有收到新数据")
-                                
-                                # 如果超过15秒没有收到新数据，尝试恢复连接
-                                if current_time - last_chunk_time > 60 and full_content:  # 只有在已有内容的情况下才触发
-                                    logger.warning("超过15秒无响应，主动触发恢复机制")
-                                    raise requests.exceptions.ReadTimeout("流式传输超过15秒没有新内容，可能是连接问题")
-                                
-                                last_chunk_time = current_time  # 重置计时器避免重复日志
+                                    logger.warning(
+                                        f"已经 {current_time - last_chunk_time:.1f} 秒没有收到新数据"
+                                    )
+
+                                if current_time - last_chunk_time > 60 and full_content:
+                                    logger.warning("超过60秒无响应，主动触发恢复机制")
+                                    raise requests.exceptions.ReadTimeout(
+                                        "流式传输超过60秒没有新内容，可能是连接问题"
+                                    )
                         except Exception as e:
                             logger.error(f"流式处理异常: {str(e)}")
-                            # 记录异常时的状态
-                            logger.warning(f"异常发生时状态: 已接收 {chunk_count} 块, 总长度: {len(full_content)}")
-                            
-                            # 如果已经有内容，尝试恢复连接
+                            logger.warning(
+                                f"异常发生时状态: 已接收 {chunk_count} 块, 总长度: {len(full_content)}"
+                            )
+
                             if full_content:
                                 try:
-                                    # 保存当前已接收的内容
-                                    current_content = full_content
-                                    
-                                    # 重新构建请求，添加标记表示这是恢复请求
                                     recovery_data = self.prepare_request_data(prompt, **kwargs)
-                                    
-                                    # 检查响应是否可能不完整（例如缺少结束标点或代码块未闭合）
+                                    translations = get_translation(
+                                        self.config.get('language', 'en')
+                                    )
+                                    recovery_prompt = translations.get(
+                                        'stream_continue_prompt',
+                                        'Please continue your previous answer without repeating content already provided.',
+                                    )
+
                                     unclosed_code_blocks = full_content.count('```') % 2
-                                    
-                                    # 添加恢复标记，让模型知道这是继续之前的对话
-                                    if 'contents' in recovery_data and len(recovery_data['contents']) > 0:
-                                        # 如果最后一个内容是用户消息，添加一个系统消息表示继续
-                                        translations = get_translation(self.config.get('language', 'en'))
-                                        recovery_prompt = translations.get('stream_continue_prompt', 'Please continue your previous answer without repeating content already provided.')
-                                        
-                                        # 根据不同的不完整情况生成不同的恢复提示
-                                        if unclosed_code_blocks:
-                                            recovery_prompt += translations.get('stream_continue_code_blocks', 'Your previous answer had unclosed code blocks. Please continue and complete these code blocks.')
-                                        
-                                        recovery_data['contents'].append({
+                                    if unclosed_code_blocks:
+                                        recovery_prompt += translations.get(
+                                            'stream_continue_code_blocks',
+                                            ' Your previous answer had unclosed code blocks. Please continue and complete these code blocks.',
+                                        )
+
+                                    recovery_data['contents'].append(
+                                        {
+                                            "role": "model",
+                                            "parts": [{"text": full_content}],
+                                        }
+                                    )
+                                    recovery_data['contents'].append(
+                                        {
                                             "role": "user",
-                                            "parts": [{"text": recovery_prompt}]
-                                        })
-                                    
-                                    # 设置更长的超时时间
+                                            "parts": [{"text": recovery_prompt}],
+                                        }
+                                    )
+
                                     recovery_timeout = kwargs.get('timeout', 300) + 60
-                                    
-                                    
-                                    # 发起恢复请求
+
                                     with requests.post(
                                         url,
                                         headers=headers,
                                         json=recovery_data,
                                         params=params,
                                         timeout=recovery_timeout,
-                                        stream=True
+                                        stream=True,
                                     ) as recovery_response:
                                         recovery_response.raise_for_status()
-                                        
-                                        # 处理恢复响应
+
                                         for line in recovery_response.iter_lines():
                                             if line:
                                                 line = line.decode('utf-8')
-                                                
+
                                                 if line.startswith('data: '):
                                                     line = line[6:]
-                                                    
+
                                                     if line.strip() == "[DONE]":
                                                         break
-                                                    
+
                                                     try:
                                                         chunk_data = json.loads(line)
-                                                        
-                                                        if 'candidates' in chunk_data and chunk_data['candidates']:
+
+                                                        if (
+                                                            'candidates' in chunk_data
+                                                            and chunk_data['candidates']
+                                                        ):
                                                             candidate = chunk_data['candidates'][0]
-                                                            if 'content' in candidate:
-                                                                content = candidate['content']
-                                                                if 'parts' in content and content['parts']:
-                                                                    for part in content['parts']:
-                                                                        if 'text' in part and part['text']:
-                                                                            chunk_text = part['text']
-                                                                            full_content += chunk_text
-                                                                            stream_callback(chunk_text)
-                                                                            chunk_count += 1
-                                                                            last_chunk_time = time.time()
+                                                            chunk_text = self._extract_text_from_candidate(
+                                                                candidate
+                                                            )
+                                                            if chunk_text:
+                                                                full_content += chunk_text
+                                                                stream_callback(chunk_text)
+                                                                chunk_count += 1
+                                                                last_chunk_time = time.time()
                                                     except json.JSONDecodeError as je:
-                                                        logger.error(f"恢复请求JSON解析错误: {str(je)}")
+                                                        logger.error(
+                                                            f"恢复请求JSON解析错误: {str(je)}"
+                                                        )
                                                         continue
-                                        
+
                                 except Exception as recovery_e:
                                     logger.error(f"恢复连接失败: {str(recovery_e)}")
-                                    logger.warning(f"将返回已接收的 {len(full_content)} 字符内容")
+                                    logger.warning(
+                                        f"将返回已接收的 {len(full_content)} 字符内容"
+                                    )
                             else:
-                                raise  # 如果没有内容，抛出异常
-                    
-                    
+                                raise
+
                     return full_content
                 else:
-                    # 普通请求处理
-                    try:
-                        
-                        response = requests.post(
-                            url,
-                            headers=headers,
-                            json=data,
-                            params=params,
-                            timeout=kwargs.get('timeout', 300)  # 增加超时时间
+                    response = requests.post(
+                        url,
+                        headers=headers,
+                        json=data,
+                        params=params,
+                        timeout=kwargs.get('timeout', 300),
+                    )
+                    response.raise_for_status()
+
+                    result = response.json()
+
+                    if 'candidates' in result and result['candidates']:
+                        candidate = result['candidates'][0]
+                        content = self._extract_text_from_candidate(candidate)
+                        if content:
+                            return content
+
+                    translations = get_translation(self.config.get('language', 'en'))
+                    error_msg = translations.get(
+                        'api_invalid_response',
+                        'Unable to get valid API response',
+                    )
+                    if 'error' in result:
+                        error_msg = (
+                            f"{error_msg}: "
+                            f"{result['error'].get('message', translations.get('unknown_error', 'Unknown error'))}"
                         )
-                        response.raise_for_status()
-                        
-                        result = response.json()
-                        
-                        # 解析 Gemini API 响应
-                        if 'candidates' in result and result['candidates']:
-                            candidate = result['candidates'][0]
-                            if 'content' in candidate and 'parts' in candidate['content']:
-                                text_parts = [part['text'] for part in candidate['content']['parts'] if 'text' in part]
-                                content = ''.join(text_parts)
-                                return content
-                        
-                        # 如果无法获取响应内容，返回错误信息
-                        translations = get_translation(self.config.get('language', 'en'))
-                        error_msg = translations.get('api_invalid_response', 'Unable to get valid API response')
-                        if 'error' in result:
-                            error_msg = f"{error_msg}: {result['error'].get('message', translations.get('unknown_error', 'Unknown error'))}"
-                        logger.error(f"Gemini API 响应解析失败: {error_msg}")
-                        raise Exception(error_msg)
-                    except requests.exceptions.RequestException as req_e:
-                        logger.error(f"Gemini API 请求异常: {str(req_e)}")
-                        if hasattr(req_e, 'response') and req_e.response is not None:
-                            try:
-                                error_detail = req_e.response.json()
-                                logger.error(f"错误详情: {json.dumps(error_detail, ensure_ascii=False)}")
-                            except Exception:
-                                logger.error(f"响应内容: {req_e.response.text[:500]}")
-                        raise
-            
+                    logger.error(f"Gemini API 响应解析失败: {error_msg}")
+                    raise Exception(error_msg)
+
             except requests.exceptions.RequestException as e:
                 logger.error(f"请求异常: {str(e)}")
-                
+
                 if attempt < max_retries - 1:
-                    # 如果不是最后一次尝试，则等待后重试
-                    retry_wait = retry_delay * (2 ** attempt)  # 指数退避
+                    retry_wait = retry_delay * (2 ** attempt)
                     time.sleep(retry_wait)
                     continue
-                
-                # 最后一次尝试失败，提供详细错误信息
+
                 translations = get_translation(self.config.get('language', 'en'))
-                error_msg = translations.get('api_request_failed', 'API request failed: {error}').format(error=str(e))
-                
+                error_msg = translations.get(
+                    'api_request_failed',
+                    'API request failed: {error}',
+                ).format(error=str(e))
+
                 if hasattr(e, 'response') and e.response is not None:
                     try:
                         error_detail = e.response.json()
-                        
-                        # 根据错误类型提供更具体的错误信息
+
                         if e.response.status_code == 404:
-                            error_msg = translations.get('api_version_model_error', 'API version or model name error: {message}\n\nPlease update API Base URL to "{base_url}" and model to "{model}" or other available model in settings.').format(
+                            error_msg = translations.get(
+                                'api_version_model_error',
+                                'API version or model name error: {message}\n\n'
+                                'Please update API Base URL to "{base_url}" and model to "{model}" '
+                                'or other available model in settings.',
+                            ).format(
                                 message=error_detail.get('error', {}).get('message', ''),
                                 base_url=self.DEFAULT_API_BASE_URL,
-                                model=self.DEFAULT_MODEL
+                                model=self.DEFAULT_MODEL,
                             )
                         elif e.response.status_code == 400:
-                            error_msg = translations.get('api_format_error', 'API request format error: {message}').format(
-                                message=error_detail.get('error', {}).get('message', '')
-                            )
+                            message = error_detail.get('error', {}).get('message', '')
+                            if 'location is not supported' in message.lower():
+                                error_msg = translations.get(
+                                    'gemini_geo_restriction',
+                                    'Gemini API is not available in your region.',
+                                )
+                            else:
+                                error_msg = translations.get(
+                                    'api_format_error',
+                                    'API request format error: {message}',
+                                ).format(message=message)
                         elif e.response.status_code == 401:
-                            error_msg = translations.get('api_key_invalid', 'API Key invalid or unauthorized: {message}\n\nPlease check your API Key and ensure API access is enabled.').format(
+                            error_msg = translations.get(
+                                'api_key_invalid',
+                                'API Key invalid or unauthorized: {message}\n\n'
+                                'Please check your API Key and ensure API access is enabled.',
+                            ).format(
                                 message=error_detail.get('error', {}).get('message', '')
                             )
                         elif e.response.status_code == 429:
-                            error_msg = translations.get('api_rate_limit', 'Request rate limit exceeded, please try again later\n\nYou may have exceeded the free usage quota. This could be due to:\n1. Too many requests per minute\n2. Too many requests per day\n3. Too many input tokens per minute')
+                            error_msg = translations.get(
+                                'api_rate_limit',
+                                'Request rate limit exceeded, please try again later\n\n'
+                                'You may have exceeded the free usage quota. This could be due to:\n'
+                                '1. Too many requests per minute\n'
+                                '2. Too many requests per day\n'
+                                '3. Too many input tokens per minute',
+                            )
                     except Exception:
-                        error_msg += f" | 响应内容: {e.response.text[:200] if hasattr(e.response, 'text') else '无法解析响应'}"
-                
+                        error_msg += (
+                            f" | 响应内容: "
+                            f"{e.response.text[:200] if hasattr(e.response, 'text') else '无法解析响应'}"
+                        )
+
                 raise Exception(error_msg) from e
-    
+
     def get_model_name(self) -> str:
         """
         获取当前模型名称
-        
+
         :return: 模型名称字符串
         """
-        return self.config.get('model', self.DEFAULT_MODEL)
-    
+        return self.normalize_model_name(
+            self.config.get('model', self.DEFAULT_MODEL),
+            self.DEFAULT_MODEL,
+        )
+
     def get_provider_name(self) -> str:
         """
         获取提供商名称
-        
+
         :return: 提供商名称字符串
         """
         return "Google Gemini"
-    
+
     def supports_streaming(self) -> bool:
         """
         检查 Gemini 模型是否支持流式传输
-        
+
         :return: 始终返回 True，因为 Gemini API 支持流式传输
         """
         return True
-        
+
     @classmethod
     def get_default_config(cls) -> Dict[str, Any]:
         """
         获取 Gemini 模型的默认配置
-        
+
         :return: 默认配置字典
         """
         return {
             "api_key": "",
             "api_base_url": cls.DEFAULT_API_BASE_URL,
             "model": cls.DEFAULT_MODEL,
-            "enable_streaming": True,  # 默认启用流式传输
+            "enable_streaming": True,
         }
-    
+
     def prepare_models_request_headers(self) -> Dict[str, str]:
         """
         准备获取模型列表的请求头
-        Gemini 获取模型列表时不需要在请求头中添加 API key
-        API key 通过 URL 参数传递
-        
-        GET 请求不需要 Content-Type 头
-        
+        最新推荐使用 x-goog-api-key，GET 请求不需要 Content-Type
+
         :return: 请求头字典
         """
-        return {}
-    
+        headers = {}
+        api_key = self.get_token()
+        if api_key:
+            headers["x-goog-api-key"] = api_key
+        return headers
+
     def prepare_models_request_url(self, base_url: str, endpoint: str) -> str:
         """
-        准备获取模型列表的完整 URL
-        Gemini 将 API key 作为 URL 参数
-        
+        准备获取模型列表的完整 URL（不再把 API key 放进查询参数）
+
         :param base_url: API 基础 URL
         :param endpoint: API 端点路径
         :return: 完整的请求 URL
         """
-        api_key = self.config.get('api_key', '')
-        return f"{base_url}{endpoint}?key={api_key}"
-    
+        return self.build_api_url(base_url, endpoint)
+
     def parse_models_response(self, data: Dict[str, Any]) -> list:
         """
         解析 Gemini API 的模型列表响应
-        Gemini 使用 "models" 字段，且模型名称有 "models/" 前缀需要移除
-        
+        移除 models/ 前缀，并优先保留支持 generateContent 的模型
+
         :param data: API 响应的 JSON 数据
         :return: 模型名称列表
         """
         models = []
         for model in data.get('models', []):
+            methods = model.get('supportedGenerationMethods') or model.get('supportedActions') or []
+            if methods and 'generateContent' not in methods:
+                continue
+
             model_name = model.get('name', '')
-            # Remove "models/" prefix if present
             if model_name.startswith('models/'):
-                models.append(model_name.replace('models/', ''))
-            else:
+                model_name = model_name.replace('models/', '', 1)
+            if model_name:
                 models.append(model_name)
         return models
-    
+
     def verify_api_key_with_test_request(self) -> None:
         """
-        Gemini 使用 URL 参数传递 API Key，需要自定义验证逻辑
+        使用最新 header 认证方式验证 API Key
         """
-        import logging
-        from calibre_plugins.ask_ai_plugin.lib.ask_ai_plugin_vendor import requests
         from ..i18n import get_translation
-        
-        logger = logging.getLogger(self.get_logger_name())
+
         provider_name = self.get_provider_name()
-        
+        timeout_seconds = 15
+
         try:
-            # Gemini 的验证：发送一个最小的 generateContent 请求
-            api_key = self.config.get('api_key', '')
             api_base_url = self.config.get('api_base_url', self.DEFAULT_API_BASE_URL)
-            model_name = self.DEFAULT_MODEL
-            
-            # Gemini 的 API Key 通过 URL 参数传递
-            url = f"{api_base_url}/models/{model_name}:generateContent?key={api_key}"
-            
-            # 最小的测试请求
+            model_name = self.normalize_model_name(
+                self.config.get('model', self.DEFAULT_MODEL),
+                self.DEFAULT_MODEL,
+            )
+            url = self._build_generate_url(model_name, api_base_url, use_stream=False)
+
             test_data = {
-                "contents": [{
-                    "parts": [{"text": "hi"}]
-                }],
+                "contents": [
+                    {
+                        "role": "user",
+                        "parts": [{"text": "hi"}],
+                    }
+                ],
                 "generationConfig": {
-                    "maxOutputTokens": 1
-                }
+                    "maxOutputTokens": 1,
+                },
             }
-            
-            headers = {"Content-Type": "application/json"}
-            
-            
-            # 在线模型超时时间（15秒）
-            timeout_seconds = 15
+
+            headers = self.prepare_headers()
+
             response = requests.post(
                 url,
                 headers=headers,
                 json=test_data,
                 timeout=timeout_seconds,
             )
-            
+
             logger.info(f"[{provider_name}] 测试请求响应状态码: {response.status_code}")
             logger.debug(f"[{provider_name}] 测试请求响应内容: {response.text[:200]}")
-            
-            if response.status_code == 401 or response.status_code == 403:
+
+            if response.status_code in (401, 403):
                 logger.error(f"[{provider_name}] API Key 无效 - {response.status_code}")
                 translations = get_translation(self.config.get('language', 'en'))
-                error_msg = translations.get('error_401', 
-                    'API Key authentication failed. Please check: API Key is correct, account has sufficient balance, API Key has not expired.')
+                error_msg = translations.get(
+                    'error_401',
+                    'API Key authentication failed. Please check: API Key is correct, '
+                    'account has sufficient balance, API Key has not expired.',
+                )
                 tech_details = translations.get('technical_details', 'Technical Details')
-                raise Exception(f"{error_msg}\n\n{tech_details}: HTTP {response.status_code} - Invalid API Key")
-            
-            elif response.status_code in [200, 400]:
-                logger.info(f"[{provider_name}] API Key 验证成功 - 状态码: {response.status_code}")
-            
+                raise Exception(
+                    f"{error_msg}\n\n{tech_details}: HTTP {response.status_code} - Invalid API Key"
+                )
+
+            if response.status_code in (200, 400):
+                logger.info(
+                    f"[{provider_name}] API Key 验证成功 - 状态码: {response.status_code}"
+                )
             else:
-                logger.warning(f"[{provider_name}] 收到未预期的状态码: {response.status_code}")
-                
+                logger.warning(
+                    f"[{provider_name}] 收到未预期的状态码: {response.status_code}"
+                )
+
         except requests.exceptions.Timeout as e:
-            # 超时错误 - 添加超时时间信息
             logger.error(f"[{provider_name}] API Key 验证请求超时: {str(e)}")
             translations = get_translation(self.config.get('language', 'en'))
-            error_msg = translations.get('error_network', 
-                'Network connection failed. Please check network connection, proxy settings, or firewall configuration.')
+            error_msg = translations.get(
+                'error_network',
+                'Network connection failed. Please check network connection, '
+                'proxy settings, or firewall configuration.',
+            )
             tech_details = translations.get('technical_details', 'Technical Details')
-            raise Exception(f"{error_msg}\n\n{tech_details}: Timeout after {timeout_seconds} seconds")
-        
+            raise Exception(
+                f"{error_msg}\n\n{tech_details}: Timeout after {timeout_seconds} seconds"
+            )
+
         except requests.exceptions.RequestException as e:
             logger.error(f"[{provider_name}] API Key 验证请求失败: {str(e)}")
             if hasattr(e, 'response') and e.response is not None:
                 if e.response.status_code in [401, 403]:
                     translations = get_translation(self.config.get('language', 'en'))
-                    error_msg = translations.get('error_401', 
-                        'API Key authentication failed. Please check: API Key is correct, account has sufficient balance, API Key has not expired.')
+                    error_msg = translations.get(
+                        'error_401',
+                        'API Key authentication failed. Please check: API Key is correct, '
+                        'account has sufficient balance, API Key has not expired.',
+                    )
                     tech_details = translations.get('technical_details', 'Technical Details')
                     raise Exception(f"{error_msg}\n\n{tech_details}: {str(e)}")
             logger.info(f"[{provider_name}] API Key 验证通过（收到非401/403响应）")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Google Gemini provider to match the current Gemini REST API request format and fixes several request bugs that could cause 404s or incorrect prompts.

## What was wrong

- Default model used OpenRouter-style `google/gemini-3.5-flash` against `generativelanguage.googleapis.com` (should be `gemini-3.5-flash`)
- System prompt was sent as a fake `role: user` content item instead of `systemInstruction`
- `ask()` ignored saved `config` model / base URL and always fell back to defaults from kwargs
- `maxOutputTokens` was always overwritten to `128000`
- Models list / key verification still preferred URL `?key=` auth; docs were outdated
- Streaming idle timer was reset every loop iteration, defeating the timeout

## Changes

- [`models/gemini.py`](models/gemini.py)
  - Auth via `x-goog-api-key` for chat, model list, and key verification
  - Request body uses `systemInstruction` + `contents[].role/parts`
  - Native default model: `gemini-3.5-flash`
  - Normalize legacy `models/` and `google/` prefixes
  - Use configured model/base URL; fix streaming timeout and recovery as multi-turn continue
- [`models/base.py`](models/base.py): default model name updated
- [`aiprovider/gemini.md`](aiprovider/gemini.md): docs aligned with latest format

## Test plan

- [x] Static checks: default model, `systemInstruction`, header auth, model-name normalization
- [x] `py_compile models/gemini.py`
- [ ] In calibre: configure Gemini API key → refresh models → send a question (non-stream and stream)
- [ ] Confirm old saved model values like `google/gemini-3.5-flash` still work via normalization

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f77e2-e367-7ddc-b566-0656e4060a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f77e2-e367-7ddc-b566-0656e4060a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

