### PR TITLE
Update Anthropic Messages and OpenAI Responses request protocols

### DIFF
--- a/aiprovider/anthropic.md
+++ b/aiprovider/anthropic.md
@@ -3,31 +3,36 @@
 ## 核心配置
 
 - **API Key**: 必需。在请求头中作为 `x-api-key` 发送。
-- **Base URL**: 必需。这是 API 的根地址，例如 `https://api.anthropic.com/v1`。
+- **Base URL**: 必需。例如 `https://api.anthropic.com/v1`。
+- **API Version**: 必需请求头 `anthropic-version: 2023-06-01`。
 
 ## 获取模型列表
 
-- **端点**: Anthropic 不提供公开的、用于自动获取模型列表的 API 端点。
-- **方法**: N/A
-- **解决方案**: 模型名称需要用户手动输入或在前端硬编码。
+- **端点**: `${baseUrl}/models`
+- **方法**: `GET`
+- **认证与请求头**:
+  ```http
+  x-api-key: ${apiKey}
+  anthropic-version: 2023-06-01
+  ```
+- **响应**: `{"data":[{"id":"claude-opus-4-8", ...}]}`
 
 ## 发送聊天请求
 
 - **端点**: `${baseUrl}/messages`
 - **方法**: `POST`
 - **认证与请求头**:
-  ```json
-  {
-    "Content-Type": "application/json",
-    "x-api-key": "${apiKey}",
-    "anthropic-version": "2023-06-01" // 版本号是必需的
-  }
+  ```http
+  Content-Type: application/json
+  x-api-key: ${apiKey}
+  anthropic-version: 2023-06-01
   ```
 - **请求体 (Body)**:
   ```json
   {
-    "model": "<模型名称>",
-    "max_tokens": 4096, // 建议设置一个最大输出长度
+    "model": "claude-opus-4-8",
+    "max_tokens": 4096,
+    "system": "<系统提示词>",
     "messages": [
       {
         "role": "user",
@@ -37,13 +42,14 @@
   }
   ```
 
+## 实现要点
+
+1. 系统提示使用顶层 `system`，不要放进 `messages` 的 `role: system`（除非你明确使用 mid-conversation system 能力）。
+2. `max_tokens` 是必填字段。
+3. **Claude Opus 4.7 / 4.8 及更新 Opus**：不要发送 `temperature` / `top_p` / `top_k`，否则会返回 400。
+4. 流式响应监听 `content_block_delta`（`text_delta`）与 `message_stop`。
+5. 非流式响应从 `content[]` 中拼接所有 `type: "text"` 块。
+
 ## 总结
 
-Anthropic 的 API 有两个关键点：
-1.  支持自动获取模型列表
-
-curl https://api.anthropic.com/v1/models \
-     --header "x-api-key: $ANTHROPIC_API_KEY" \
-     --header "anthropic-version: 2023-06-01"
-
-2.  请求头中除了 API Key (`x-api-key`)，还必须包含一个明确的 API 版本号 (`anthropic-version`)。
+Anthropic Messages API 的关键是：`x-api-key` + `anthropic-version`，以及按模型代际正确省略采样参数。

--- a/aiprovider/openai.md
+++ b/aiprovider/openai.md
@@ -1,0 +1,61 @@
+# OpenAI (ChatGPT) 配置指南
+
+Ask AI Plugin 的 **OpenAI** 提供商使用最新推荐的 **Responses API**（不再使用 Chat Completions）。
+
+> 其他 OpenAI 兼容提供商（DeepSeek、OpenRouter、Custom 等）仍使用 `/chat/completions`，见 [openai_compatible.md](./openai_compatible.md)。
+
+## 核心配置
+
+- **API Key**: 必需。`Authorization: Bearer ${apiKey}`
+- **Base URL**: 必需。例如 `https://api.openai.com/v1`
+- **Model**: 例如 `gpt-5.4`
+
+## 获取模型列表
+
+- **端点**: `${baseUrl}/models`
+- **方法**: `GET`
+- **认证**:
+  ```http
+  Authorization: Bearer ${apiKey}
+  ```
+
+## 发送聊天请求（Responses API）
+
+- **端点**: `${baseUrl}/responses`
+- **方法**: `POST`
+- **认证**:
+  ```http
+  Authorization: Bearer ${apiKey}
+  Content-Type: application/json
+  ```
+- **请求体 (Body)**:
+  ```json
+  {
+    "model": "gpt-5.4",
+    "instructions": "<系统提示词>",
+    "input": "<用户提示词>",
+    "store": false,
+    "temperature": 0.7
+  }
+  ```
+
+### 字段说明
+
+| Chat Completions（旧） | Responses（现用） |
+| --- | --- |
+| `messages[]` | `instructions` + `input` |
+| `max_tokens` | `max_output_tokens` |
+| `choices[0].message.content` | `output_text` 或 `output[].content[].text` |
+| 默认可能存储 | 插件默认 `store: false` |
+
+## 流式传输
+
+- 请求体增加 `"stream": true`
+- 关注 SSE 事件：
+  - `response.output_text.delta`（字段 `delta`）
+  - `response.completed`
+  - `error`
+
+## 总结
+
+OpenAI/ChatGPT 提供商现已对齐官方推荐的 Responses 协议：`/v1/responses` + `instructions`/`input` + `store: false`。

--- a/aiprovider/openai_compatible.md
+++ b/aiprovider/openai_compatible.md
@@ -1,11 +1,13 @@
-# OpenAI 及其兼容提供商配置指南
+# OpenAI 兼容提供商配置指南
 
-此指南适用于 OpenAI 以及遵循其 API 格式的兼容提供商，包括 **DeepSeek, Qwen, OpenRouter, xAI, Nvidia, Custom**。
+此指南适用于遵循 **Chat Completions** 格式的兼容提供商，包括 **DeepSeek, Qwen, OpenRouter, xAI, Nvidia, Custom, Mistral, Kimi** 等。
+
+> 插件内置的 **OpenAI (ChatGPT)** 提供商已改用 Responses API，请看 [openai.md](./openai.md)。
 
 ## 核心配置
 
 - **API Key**: 必需。在请求头中作为 Bearer Token 发送。
-- **Base URL**: 必需。这是 API 的根地址，例如 `https://api.openai.com/v1`。
+- **Base URL**: 必需。这是 API 的根地址，例如 `https://api.deepseek.com`。
 
 ## 获取模型列表
 
@@ -45,4 +47,4 @@
 
 ## 总结
 
-这类提供商遵循了统一的 API 标准，配置相对简单。主要挑战在于处理像 Nvidia 这样的特例所带来的 CORS 问题。
+这类提供商遵循 Chat Completions API 标准，配置相对简单。真正的 OpenAI/ChatGPT 官方接口请改用 Responses API。

--- a/models/anthropic.py
+++ b/models/anthropic.py
@@ -1,10 +1,17 @@
 """
 Anthropic (Claude) AI Model Implementation
+
+Uses the Messages API:
+- POST /v1/messages
+- Headers: x-api-key + anthropic-version: 2023-06-01
+- System prompt via top-level `system`
+- Opus 4.7+ reject temperature/top_p/top_k
 """
 import json
+import re
 import time
 import logging
-from typing import Dict, Any, Optional
+from typing import Dict, Any, List
 
 # 从 vendor 命名空间导入第三方库
 from calibre_plugins.ask_ai_plugin.lib.ask_ai_plugin_vendor import requests
@@ -12,340 +19,450 @@ from calibre_plugins.ask_ai_plugin.lib.ask_ai_plugin_vendor import requests
 from .base import BaseAIModel
 from ..i18n import get_translation
 
+logger = logging.getLogger('calibre_plugins.ask_ai_plugin.models.anthropic')
+
 
 class AnthropicModel(BaseAIModel):
     """
     Anthropic (Claude) AI Model Implementation Class
-    Supports Claude 3.5 Sonnet, Claude 3 Opus, and other Claude models
     """
     # Default model name
     DEFAULT_MODEL = "claude-opus-4-8"
     # Default API base URL
     DEFAULT_API_BASE_URL = "https://api.anthropic.com/v1"
-    # Required Anthropic API version
+    # Required Anthropic API version (still current)
     ANTHROPIC_VERSION = "2023-06-01"
-    
+
     def _validate_config(self):
         """
         Validate Anthropic model configuration
-        
+
         :raises ValueError: When configuration is invalid
         """
-        # 基本必需字段（不包括 model，因为在获取模型列表时可能为空）
         required_keys = ['api_key', 'api_base_url']
         for key in required_keys:
             if not self.config.get(key):
                 translations = get_translation(self.config.get('language', 'en'))
-                raise ValueError(translations.get('missing_required_config', 'Missing required configuration: {key}').format(key=key))
-        
-        # 如果 model 为空，使用默认值
+                raise ValueError(
+                    translations.get(
+                        'missing_required_config',
+                        'Missing required configuration: {key}',
+                    ).format(key=key)
+                )
+
         if not self.config.get('model'):
             self.config['model'] = self.DEFAULT_MODEL
-    
+
     def get_token(self) -> str:
         """
         Get Anthropic model API Key/Token
-        
+
         :return: API Key/Token string
         """
         return self.config.get('api_key', '')
-    
+
     def validate_token(self) -> bool:
         """
         Validate if Anthropic model token is valid
-        
+
         :return: True if token is valid
         :raises ValueError: When token is invalid
         """
-        # First call base class basic validation
         super().validate_token()
-        
+
         token = self.get_token()
-        
-        # Anthropic API Key format validation: basic length check
         if len(token) < 20:
             translations = get_translation(self.config.get('language', 'en'))
-            raise ValueError(translations.get('api_key_too_short', 'API Key is too short. Please check and enter the complete key.'))
-        
+            raise ValueError(
+                translations.get(
+                    'api_key_too_short',
+                    'API Key is too short. Please check and enter the complete key.',
+                )
+            )
+
         return True
-    
+
     def prepare_headers(self) -> Dict[str, str]:
         """
         Prepare Anthropic API request headers
-        Note: Anthropic uses x-api-key header instead of Authorization Bearer
-        
+
         :return: Request headers dictionary
         """
         return {
             "Content-Type": "application/json",
             "x-api-key": self.get_token(),
-            "anthropic-version": self.ANTHROPIC_VERSION
+            "anthropic-version": self.ANTHROPIC_VERSION,
         }
-    
+
+    @staticmethod
+    def supports_sampling_params(model_name: str) -> bool:
+        """
+        Claude Opus 4.7+ reject temperature/top_p/top_k (400 if set).
+
+        :param model_name: Model id
+        :return: True if sampling params are allowed
+        """
+        name = (model_name or '').lower()
+        match = re.search(r'claude-opus-4(?:\.|-)(\d+)', name)
+        if match and int(match.group(1)) >= 7:
+            return False
+        # Also cover aliases like claude-opus-4-7 / claude-opus-4-8 without regex miss
+        if 'opus-4-7' in name or 'opus-4-8' in name or 'opus-4.7' in name or 'opus-4.8' in name:
+            return False
+        return True
+
+    @staticmethod
+    def extract_text_from_content(content_blocks: Any) -> str:
+        """
+        Extract assistant text from Messages API content blocks.
+
+        :param content_blocks: Response content array or string
+        :return: Concatenated text
+        """
+        if isinstance(content_blocks, str):
+            return content_blocks
+
+        if not isinstance(content_blocks, list):
+            return ''
+
+        texts: List[str] = []
+        for block in content_blocks:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get('type')
+            if block_type == 'text' and block.get('text'):
+                texts.append(block['text'])
+            elif block_type == 'thinking' and block.get('thinking'):
+                # Keep thinking visible for book-analysis debugging when returned
+                texts.append(f"<think>{block['thinking']}</think>\n\n")
+        return ''.join(texts)
+
     def prepare_request_data(self, prompt: str, **kwargs) -> Dict[str, Any]:
         """
-        Prepare Anthropic API request data
-        Note: Anthropic requires max_tokens field
-        
+        Prepare Anthropic Messages API request data
+
         :param prompt: Prompt text
         :param kwargs: Other parameters like temperature, stream, etc.
         :return: Request data dictionary
         """
         translations = get_translation(self.config.get('language', 'en'))
-        system_message = kwargs.get('system_message', translations.get('default_system_message', 'You are an expert in book analysis. Your task is to help users understand books better by providing insightful questions and analysis.'))
-        
-        data = {
-            "model": self.config.get('model', self.DEFAULT_MODEL),
-            "max_tokens": kwargs.get('max_tokens', 4096),  # Required field for Anthropic
+        system_message = kwargs.get(
+            'system_message',
+            translations.get(
+                'default_system_message',
+                'You are an expert in book analysis. Your task is to help users understand books better by providing insightful questions and analysis.',
+            ),
+        )
+
+        model_name = kwargs.get('model') or self.config.get('model', self.DEFAULT_MODEL)
+
+        data: Dict[str, Any] = {
+            "model": model_name,
+            "max_tokens": kwargs.get('max_tokens', 4096),
             "messages": [
                 {
                     "role": "user",
-                    "content": prompt
+                    "content": prompt,
                 }
             ],
-            "temperature": kwargs.get('temperature', 0.7)
         }
-        
-        # Add system message if provided (Anthropic uses separate system field)
-        if system_message:
+
+        if system_message and str(system_message).strip():
             data['system'] = system_message
-        
-        # Add streaming support (only add if explicitly set to True)
+
+        # Only include sampling params on models that still accept them
+        if self.supports_sampling_params(model_name):
+            data['temperature'] = kwargs.get('temperature', 0.7)
+            if kwargs.get('top_p') is not None:
+                data['top_p'] = kwargs.get('top_p')
+            if kwargs.get('top_k') is not None:
+                data['top_k'] = kwargs.get('top_k')
+
         if kwargs.get('stream', False):
             data['stream'] = True
-            
+
         return data
-    
+
     def ask(self, prompt: str, **kwargs) -> str:
         """
-        Send prompt to Anthropic API and get response
-        
+        Send prompt to Anthropic Messages API and get response
+
         :param prompt: Prompt text
         :param kwargs: Other parameters like temperature, stream, stream_callback, etc.
         :return: AI model response text
         :raises Exception: When request fails
         """
-        # Prepare request headers and data
         headers = self.prepare_headers()
         data = self.prepare_request_data(prompt, **kwargs)
-        
-        # Check if using streaming
+
         use_stream = kwargs.get('stream', self.config.get('enable_streaming', True))
         stream_callback = kwargs.get('stream_callback', None)
-        
+
+        api_base_url = kwargs.get('api_base_url') or self.config.get(
+            'api_base_url', self.DEFAULT_API_BASE_URL
+        )
+        api_url = self.build_api_url(api_base_url, '/messages')
+
         try:
-            # If using streaming
             if use_stream and stream_callback:
                 full_content = ""
                 chunk_count = 0
                 last_chunk_time = time.time()
-                logger = logging.getLogger('calibre_plugins.ask_ai_plugin.models.anthropic')
-                
-                api_url = self.build_api_url(self.config['api_base_url'], '/messages')
-                
-                try:
-                    with requests.post(
-                        api_url,
-                        headers=headers,
-                        json=data,
-                        timeout=kwargs.get('timeout', 300),
-                        stream=True,
-                    ) as response:
-                        response.raise_for_status()
-                        
-                        for line in response.iter_lines():
-                            if line:
-                                line_str = line.decode('utf-8')
-                                if line_str.startswith('data: '):
-                                    # Handle data line
-                                    try:
-                                        line_data = json.loads(line_str[6:])  # Remove 'data: ' prefix
-                                        
-                                        # Anthropic streaming format
-                                        if line_data.get('type') == 'content_block_delta':
-                                            if 'delta' in line_data and line_data['delta'].get('type') == 'text_delta':
-                                                chunk_text = line_data['delta'].get('text', '')
-                                                if chunk_text:
-                                                    full_content += chunk_text
-                                                    stream_callback(chunk_text)
-                                                    chunk_count += 1
-                                                    last_chunk_time = time.time()
-                                        elif line_data.get('type') == 'message_stop':
-                                            break
-                                    except json.JSONDecodeError as je:
-                                        logger.error(f"JSON parse error: {str(je)}, line content: {line_str[:50]}...")
-                                        continue
-                                    
-                                # Check if no new data received for 15 seconds
-                                current_time = time.time()
-                                if current_time - last_chunk_time > 15:
-                                    logger.warning(f"No new data received for {current_time - last_chunk_time:.1f} seconds")
-                                
-                                # If no new data for 60 seconds, try to recover connection
-                                if current_time - last_chunk_time > 60 and full_content:
-                                    logger.warning("No response for over 60 seconds, triggering recovery mechanism")
-                                    translations = get_translation(self.config.get('language', 'en'))
-                                    raise requests.exceptions.ReadTimeout(translations.get('stream_timeout_error', "Streaming timeout after 60 seconds with no new content, possible connection issue"))
-                        
-                        logger.info(f"Streaming completed, received {chunk_count} chunks, total length: {len(full_content)}")
-                        return full_content
-                        
-                except requests.exceptions.RequestException as e:
-                    logger.error(f"Anthropic API request error: {str(e)}")
-                    translations = get_translation(self.config.get('language', 'en'))
-                    raise Exception(translations.get('api_request_failed', 'API request failed: {error}').format(error=str(e)))
-            
-            # Non-streaming mode
-            else:
-                api_url = self.build_api_url(self.config['api_base_url'], '/messages')
-                response = requests.post(
+
+                with requests.post(
                     api_url,
                     headers=headers,
                     json=data,
-                    timeout=kwargs.get('timeout', 60),
+                    timeout=kwargs.get('timeout', 300),
+                    stream=True,
+                ) as response:
+                    response.raise_for_status()
+
+                    for line in response.iter_lines():
+                        if not line:
+                            continue
+
+                        line_str = line.decode('utf-8')
+                        if not line_str.startswith('data: '):
+                            continue
+
+                        try:
+                            line_data = json.loads(line_str[6:])
+                            event_type = line_data.get('type')
+
+                            if event_type == 'content_block_delta':
+                                delta = line_data.get('delta') or {}
+                                delta_type = delta.get('type')
+                                chunk_text = ''
+                                if delta_type == 'text_delta':
+                                    chunk_text = delta.get('text', '')
+                                elif delta_type == 'thinking_delta':
+                                    chunk_text = delta.get('thinking', '')
+                                if chunk_text:
+                                    full_content += chunk_text
+                                    stream_callback(chunk_text)
+                                    chunk_count += 1
+                                    last_chunk_time = time.time()
+                            elif event_type == 'message_stop':
+                                break
+                            elif event_type == 'error':
+                                error_msg = (line_data.get('error') or {}).get(
+                                    'message', 'Unknown streaming error'
+                                )
+                                raise Exception(error_msg)
+                        except json.JSONDecodeError as je:
+                            logger.error(
+                                f"JSON parse error: {str(je)}, line content: {line_str[:50]}..."
+                            )
+                            continue
+
+                        current_time = time.time()
+                        if current_time - last_chunk_time > 15:
+                            logger.warning(
+                                f"No new data received for {current_time - last_chunk_time:.1f} seconds"
+                            )
+
+                        if current_time - last_chunk_time > 60 and full_content:
+                            logger.warning(
+                                "No response for over 60 seconds, triggering recovery mechanism"
+                            )
+                            translations = get_translation(
+                                self.config.get('language', 'en')
+                            )
+                            raise requests.exceptions.ReadTimeout(
+                                translations.get(
+                                    'stream_timeout_error',
+                                    "Streaming timeout after 60 seconds with no new content, possible connection issue",
+                                )
+                            )
+
+                logger.info(
+                    f"Streaming completed, received {chunk_count} chunks, total length: {len(full_content)}"
                 )
-                response.raise_for_status()
-                
-                result = response.json()
-                if 'content' in result and result['content']:
-                    # Anthropic returns content as array of content blocks
-                    return result['content'][0]['text']
-                else:
-                    translations = get_translation(self.config.get('language', 'en'))
-                    raise Exception(translations.get('invalid_response', 'Invalid API response format'))
-                    
+                return full_content
+
+            response = requests.post(
+                api_url,
+                headers=headers,
+                json=data,
+                timeout=kwargs.get('timeout', 60),
+            )
+            response.raise_for_status()
+
+            result = response.json()
+            content = self.extract_text_from_content(result.get('content'))
+            if content:
+                return content
+
+            translations = get_translation(self.config.get('language', 'en'))
+            raise Exception(
+                translations.get('invalid_response', 'Invalid API response format')
+            )
+
         except requests.exceptions.RequestException as e:
-            logger = logging.getLogger('calibre_plugins.ask_ai_plugin.models.anthropic')
             logger.error(f"Anthropic API request error: {str(e)}")
             translations = get_translation(self.config.get('language', 'en'))
-            raise Exception(translations.get('api_request_failed', 'API request failed: {error}').format(error=str(e)))
-    
+            error_msg = translations.get(
+                'api_request_failed',
+                'API request failed: {error}',
+            ).format(error=str(e))
+            if hasattr(e, 'response') and e.response is not None:
+                try:
+                    detail = e.response.json()
+                    message = (detail.get('error') or {}).get('message') or detail.get(
+                        'message'
+                    )
+                    if message:
+                        error_msg = f"{error_msg} | {message}"
+                except Exception:
+                    pass
+            raise Exception(error_msg) from e
+
     def send_message(self, prompt: str, callback: callable) -> None:
         """
         Send message and stream response via callback
-        
+
         :param prompt: Prompt text
         :param callback: Callback function to receive streaming text
         """
         try:
             self.ask(prompt, stream=True, stream_callback=callback)
         except Exception as e:
-            logger = logging.getLogger('calibre_plugins.ask_ai_plugin.models.anthropic')
             logger.error(f"send_message error: {str(e)}")
             raise
-    
+
     def stop_stream(self) -> None:
         """
         Stop streaming response
         Note: Current implementation does not support mid-stream interruption
         """
         pass
-    
+
     def get_model_name(self) -> str:
         """
         Get current model name
-        
+
         :return: Model name string
         """
         return self.config.get('model', self.DEFAULT_MODEL)
-    
+
     def get_provider_name(self) -> str:
         """
         Get provider name
-        
+
         :return: Provider name string
         """
         return "Anthropic (Claude)"
-    
+
     def supports_streaming(self) -> bool:
         """
         Check if model supports streaming
-        
+
         :return: True if streaming is supported
         """
-        return True  # Anthropic supports streaming
-    
+        return True
+
     def prepare_models_request_headers(self) -> Dict[str, str]:
         """
-        准备获取模型列表的请求头
-        Anthropic 使用特殊的请求头格式
-        
-        :return: 请求头字典
+        Prepare headers for GET /v1/models (no Content-Type on GET)
+
+        :return: Request headers dictionary
         """
         return {
             'x-api-key': self.config.get('api_key', ''),
             'anthropic-version': self.ANTHROPIC_VERSION,
-            'Content-Type': 'application/json'
         }
-    
+
+    def parse_models_response(self, data: Dict[str, Any]) -> list:
+        """
+        Parse Anthropic /v1/models response ({"data":[{"id": "..."}]})
+
+        :param data: API response JSON
+        :return: Model id list
+        """
+        models = []
+        for model in data.get('data', []):
+            model_id = model.get('id')
+            if model_id:
+                models.append(model_id)
+        return models
+
     def verify_api_key_with_test_request(self) -> None:
         """
-        Anthropic 使用 /messages 端点和特殊的请求头格式
+        Verify API key with a minimal Messages request
         """
-        import logging
-        from calibre_plugins.ask_ai_plugin.lib.ask_ai_plugin_vendor import requests
-        from ..i18n import get_translation
-        
-        logger = logging.getLogger(self.get_logger_name())
         provider_name = self.get_provider_name()
-        
+        timeout_seconds = 15
+
         try:
-            # Anthropic 的验证：发送一个最小的 messages 请求
             headers = self.prepare_headers()
             api_base_url = self.config.get('api_base_url', self.DEFAULT_API_BASE_URL)
-            test_url = f"{api_base_url}/messages"
-            
-            # 最小的测试请求
+            test_url = self.build_api_url(api_base_url, '/messages')
+            model_name = self.config.get('model', self.DEFAULT_MODEL)
+
             test_data = {
-                "model": self.DEFAULT_MODEL,
+                "model": model_name,
                 "messages": [{"role": "user", "content": "hi"}],
-                "max_tokens": 1
+                "max_tokens": 1,
             }
-            
+
             logger.info(f"[{provider_name}] 发送测试请求验证 API Key: {test_url}")
-            
-            # 在线模型超时时间（15秒）
-            timeout_seconds = 15
+
             response = requests.post(
                 test_url,
                 headers=headers,
                 json=test_data,
                 timeout=timeout_seconds,
             )
-            
+
             logger.info(f"[{provider_name}] 测试请求响应状态码: {response.status_code}")
             logger.debug(f"[{provider_name}] 测试请求响应内容: {response.text[:200]}")
-            
-            if response.status_code == 401 or response.status_code == 403:
+
+            if response.status_code in (401, 403):
                 logger.error(f"[{provider_name}] API Key 无效 - {response.status_code}")
                 translations = get_translation(self.config.get('language', 'en'))
-                error_msg = translations.get('error_401', 
-                    'API Key authentication failed. Please check: API Key is correct, account has sufficient balance, API Key has not expired.')
+                error_msg = translations.get(
+                    'error_401',
+                    'API Key authentication failed. Please check: API Key is correct, '
+                    'account has sufficient balance, API Key has not expired.',
+                )
                 tech_details = translations.get('technical_details', 'Technical Details')
-                raise Exception(f"{error_msg}\n\n{tech_details}: HTTP {response.status_code} - Invalid API Key")
-            
-            elif response.status_code in [200, 400, 422]:
-                logger.info(f"[{provider_name}] API Key 验证成功 - 状态码: {response.status_code}")
-            
+                raise Exception(
+                    f"{error_msg}\n\n{tech_details}: HTTP {response.status_code} - Invalid API Key"
+                )
+
+            if response.status_code in [200, 400, 422]:
+                logger.info(
+                    f"[{provider_name}] API Key 验证成功 - 状态码: {response.status_code}"
+                )
             else:
-                logger.warning(f"[{provider_name}] 收到未预期的状态码: {response.status_code}")
-                
+                logger.warning(
+                    f"[{provider_name}] 收到未预期的状态码: {response.status_code}"
+                )
+
         except requests.exceptions.Timeout as e:
-            # 超时错误 - 添加超时时间信息
             logger.error(f"[{provider_name}] API Key 验证请求超时: {str(e)}")
             translations = get_translation(self.config.get('language', 'en'))
-            error_msg = translations.get('error_network', 
-                'Network connection failed. Please check network connection, proxy settings, or firewall configuration.')
+            error_msg = translations.get(
+                'error_network',
+                'Network connection failed. Please check network connection, '
+                'proxy settings, or firewall configuration.',
+            )
             tech_details = translations.get('technical_details', 'Technical Details')
-            raise Exception(f"{error_msg}\n\n{tech_details}: Timeout after {timeout_seconds} seconds")
-        
+            raise Exception(
+                f"{error_msg}\n\n{tech_details}: Timeout after {timeout_seconds} seconds"
+            )
+
         except requests.exceptions.RequestException as e:
             logger.error(f"[{provider_name}] API Key 验证请求失败: {str(e)}")
             if hasattr(e, 'response') and e.response is not None:
                 if e.response.status_code in [401, 403]:
                     translations = get_translation(self.config.get('language', 'en'))
-                    error_msg = translations.get('error_401', 
-                        'API Key authentication failed. Please check: API Key is correct, account has sufficient balance, API Key has not expired.')
+                    error_msg = translations.get(
+                        'error_401',
+                        'API Key authentication failed. Please check: API Key is correct, '
+                        'account has sufficient balance, API Key has not expired.',
+                    )
                     tech_details = translations.get('technical_details', 'Technical Details')
                     raise Exception(f"{error_msg}\n\n{tech_details}: {str(e)}")
             logger.info(f"[{provider_name}] API Key 验证通过（收到非401/403响应）")

--- a/models/openai.py
+++ b/models/openai.py
@@ -1,10 +1,17 @@
 """
-OpenAI AI Model Implementation
+OpenAI (ChatGPT) AI Model Implementation
+
+Uses the current Responses API (recommended over Chat Completions):
+- POST /v1/responses
+- Auth: Authorization: Bearer <api_key>
+- System guidance: top-level `instructions`
+- User prompt: top-level `input`
+- Streaming events: response.output_text.delta
 """
 import json
 import time
 import logging
-from typing import Dict, Any, Optional
+from typing import Dict, Any, List
 
 # 从 vendor 命名空间导入第三方库
 from calibre_plugins.ask_ai_plugin.lib.ask_ai_plugin_vendor import requests
@@ -12,257 +19,430 @@ from calibre_plugins.ask_ai_plugin.lib.ask_ai_plugin_vendor import requests
 from .base import BaseAIModel
 from ..i18n import get_translation
 
+logger = logging.getLogger('calibre_plugins.ask_ai_plugin.models.openai')
+
 
 class OpenAIModel(BaseAIModel):
     """
-    OpenAI AI Model Implementation Class
-    Supports GPT-4, GPT-3.5, and other OpenAI models
+    OpenAI (ChatGPT) AI Model Implementation Class
+
+    Note: This provider uses the Responses API. Other OpenAI-compatible
+    providers in this plugin continue to use /chat/completions.
     """
     # Default model name
     DEFAULT_MODEL = "gpt-5.4"
     # Default API base URL
     DEFAULT_API_BASE_URL = "https://api.openai.com/v1"
-    
+
     def _validate_config(self):
         """
         Validate OpenAI model configuration
-        
+
         :raises ValueError: When configuration is invalid
         """
-        # 基本必需字段（不包括 model，因为在获取模型列表时可能为空）
         required_keys = ['api_key', 'api_base_url']
         for key in required_keys:
             if not self.config.get(key):
                 translations = get_translation(self.config.get('language', 'en'))
-                raise ValueError(translations.get('missing_required_config', 'Missing required configuration: {key}').format(key=key))
-        
-        # 如果 model 为空，使用默认值
+                raise ValueError(
+                    translations.get(
+                        'missing_required_config',
+                        'Missing required configuration: {key}',
+                    ).format(key=key)
+                )
+
         if not self.config.get('model'):
             self.config['model'] = self.DEFAULT_MODEL
-    
+
     def get_token(self) -> str:
         """
         Get OpenAI model API Key/Token
-        
+
         :return: API Key/Token string
         """
         return self.config.get('api_key', '')
-    
+
     def validate_token(self) -> bool:
         """
         Validate if OpenAI model token is valid
-        
+
         :return: True if token is valid
         :raises ValueError: When token is invalid
         """
-        # First call base class basic validation
         super().validate_token()
-        
+
         token = self.get_token()
-        
-        # OpenAI API Key format validation: basic length check
         if len(token) < 20:
             translations = get_translation(self.config.get('language', 'en'))
-            raise ValueError(translations.get('api_key_too_short', 'API Key is too short. Please check and enter the complete key.'))
-        
+            raise ValueError(
+                translations.get(
+                    'api_key_too_short',
+                    'API Key is too short. Please check and enter the complete key.',
+                )
+            )
+
         return True
-    
+
     def prepare_headers(self) -> Dict[str, str]:
         """
         Prepare OpenAI API request headers
-        
+
         :return: Request headers dictionary
         """
         token = self.get_token()
-        
-        # Ensure token has Bearer prefix
         if not token.startswith('Bearer '):
             token = f'Bearer {token}'
-            
+
         return {
             "Content-Type": "application/json",
-            "Authorization": token
+            "Authorization": token,
         }
-    
+
     def prepare_request_data(self, prompt: str, **kwargs) -> Dict[str, Any]:
         """
-        Prepare OpenAI API request data
-        
+        Prepare OpenAI Responses API request data
+
         :param prompt: Prompt text
         :param kwargs: Other parameters like temperature, stream, etc.
         :return: Request data dictionary
         """
         translations = get_translation(self.config.get('language', 'en'))
-        system_message = kwargs.get('system_message', translations.get('default_system_message', 'You are an expert in book analysis. Your task is to help users understand books better by providing insightful questions and analysis.'))
-        
-        data = {
-            "model": self.config.get('model', self.DEFAULT_MODEL),
-            "messages": [
-                {
-                    "role": "system",
-                    "content": system_message
-                },
-                {
-                    "role": "user",
-                    "content": prompt
-                }
-            ],
-            "temperature": kwargs.get('temperature', 0.7),
-            "max_tokens": kwargs.get('max_tokens', 4096)
+        system_message = kwargs.get(
+            'system_message',
+            translations.get(
+                'default_system_message',
+                'You are an expert in book analysis. Your task is to help users understand books better by providing insightful questions and analysis.',
+            ),
+        )
+
+        data: Dict[str, Any] = {
+            "model": kwargs.get('model') or self.config.get('model', self.DEFAULT_MODEL),
+            "input": prompt,
+            # Do not persist book Q&A on OpenAI servers by default
+            "store": False,
         }
-        
-        # Add streaming support (only add if explicitly set to True)
+
+        if system_message and str(system_message).strip():
+            data["instructions"] = system_message
+
+        temperature = kwargs.get('temperature', 0.7)
+        if temperature is not None:
+            data["temperature"] = temperature
+
+        max_tokens = kwargs.get('max_tokens')
+        if max_tokens is not None:
+            data["max_output_tokens"] = max_tokens
+
         if kwargs.get('stream', False):
             data['stream'] = True
-            
+
         return data
-    
+
+    @staticmethod
+    def extract_text_from_response(result: Dict[str, Any]) -> str:
+        """
+        Extract assistant text from a Responses API payload.
+
+        :param result: Parsed JSON response
+        :return: Output text
+        """
+        if not isinstance(result, dict):
+            return ''
+
+        output_text = result.get('output_text')
+        if isinstance(output_text, str) and output_text:
+            return output_text
+
+        texts: List[str] = []
+        for item in result.get('output') or []:
+            if not isinstance(item, dict):
+                continue
+            if item.get('type') != 'message':
+                continue
+            for part in item.get('content') or []:
+                if not isinstance(part, dict):
+                    continue
+                if part.get('type') in ('output_text', 'text') and part.get('text'):
+                    texts.append(part['text'])
+        return ''.join(texts)
+
     def ask(self, prompt: str, **kwargs) -> str:
         """
-        Send prompt to OpenAI API and get response
-        
+        Send prompt to OpenAI Responses API and get response
+
         :param prompt: Prompt text
         :param kwargs: Other parameters like temperature, stream, stream_callback, etc.
         :return: AI model response text
         :raises Exception: When request fails
         """
-        # Prepare request headers and data
         headers = self.prepare_headers()
         data = self.prepare_request_data(prompt, **kwargs)
-        
-        # Check if using streaming
+
         use_stream = kwargs.get('stream', self.config.get('enable_streaming', True))
         stream_callback = kwargs.get('stream_callback', None)
-        
+
+        api_base_url = kwargs.get('api_base_url') or self.config.get(
+            'api_base_url', self.DEFAULT_API_BASE_URL
+        )
+        api_url = self.build_api_url(api_base_url, '/responses')
+
         try:
-            # If using streaming
             if use_stream and stream_callback:
                 full_content = ""
                 chunk_count = 0
                 last_chunk_time = time.time()
-                logger = logging.getLogger('calibre_plugins.ask_ai_plugin.models.openai')
-                
-                api_url = f"{self.config['api_base_url']}/chat/completions"
-                
-                try:
-                    with requests.post(
-                        api_url,
-                        headers=headers,
-                        json=data,
-                        timeout=kwargs.get('timeout', 300),
-                        stream=True,
-                    ) as response:
-                        response.raise_for_status()
-                        
-                        for line in response.iter_lines():
-                            if line:
-                                line_str = line.decode('utf-8')
-                                if line_str.startswith('data: '):
-                                    # Handle data line
-                                    try:
-                                        if line_str == 'data: [DONE]':
-                                            break
-                                        line_data = json.loads(line_str[6:])  # Remove 'data: ' prefix
-                                        if 'choices' in line_data and line_data['choices']:
-                                            choice = line_data['choices'][0]
-                                            if 'delta' in choice and 'content' in choice['delta']:
-                                                chunk_text = choice['delta']['content']
-                                                if chunk_text:
-                                                    full_content += chunk_text
-                                                    stream_callback(chunk_text)
-                                                    chunk_count += 1
-                                                    last_chunk_time = time.time()
-                                    except json.JSONDecodeError as je:
-                                        logger.error(f"JSON parse error: {str(je)}, line content: {line_str[:50]}...")
-                                        continue
-                                    
-                                # Check if no new data received for 15 seconds
-                                current_time = time.time()
-                                if current_time - last_chunk_time > 15:
-                                    logger.warning(f"No new data received for {current_time - last_chunk_time:.1f} seconds")
-                                
-                                # If no new data for 60 seconds, try to recover connection
-                                if current_time - last_chunk_time > 60 and full_content:
-                                    logger.warning("No response for over 60 seconds, triggering recovery mechanism")
-                                    translations = get_translation(self.config.get('language', 'en'))
-                                    raise requests.exceptions.ReadTimeout(translations.get('stream_timeout_error', "Streaming timeout after 60 seconds with no new content, possible connection issue"))
-                        
-                        logger.info(f"Streaming completed, received {chunk_count} chunks, total length: {len(full_content)}")
-                        return full_content
-                        
-                except requests.exceptions.RequestException as e:
-                    logger.error(f"OpenAI API request error: {str(e)}")
-                    translations = get_translation(self.config.get('language', 'en'))
-                    raise Exception(translations.get('api_request_failed', 'API request failed: {error}').format(error=str(e)))
-            
-            # Non-streaming mode
-            else:
-                api_url = f"{self.config['api_base_url']}/chat/completions"
-                response = requests.post(
+
+                with requests.post(
                     api_url,
                     headers=headers,
                     json=data,
-                    timeout=kwargs.get('timeout', 60),
+                    timeout=kwargs.get('timeout', 300),
+                    stream=True,
+                ) as response:
+                    response.raise_for_status()
+
+                    for line in response.iter_lines():
+                        if not line:
+                            continue
+
+                        line_str = line.decode('utf-8')
+                        if not line_str.startswith('data: '):
+                            continue
+
+                        payload = line_str[6:].strip()
+                        if payload == '[DONE]':
+                            break
+
+                        try:
+                            event = json.loads(payload)
+                        except json.JSONDecodeError as je:
+                            logger.error(
+                                f"JSON parse error: {str(je)}, line content: {line_str[:50]}..."
+                            )
+                            continue
+
+                        event_type = event.get('type')
+                        if event_type == 'response.output_text.delta':
+                            chunk_text = event.get('delta') or ''
+                            if chunk_text:
+                                full_content += chunk_text
+                                stream_callback(chunk_text)
+                                chunk_count += 1
+                                last_chunk_time = time.time()
+                        elif event_type == 'response.completed':
+                            # Prefer final assembled text when provided
+                            completed = event.get('response') or {}
+                            final_text = self.extract_text_from_response(completed)
+                            if final_text and not full_content:
+                                full_content = final_text
+                                stream_callback(final_text)
+                            break
+                        elif event_type == 'error':
+                            message = (event.get('error') or {}).get(
+                                'message', 'Unknown streaming error'
+                            )
+                            raise Exception(message)
+
+                        current_time = time.time()
+                        if current_time - last_chunk_time > 15:
+                            logger.warning(
+                                f"No new data received for {current_time - last_chunk_time:.1f} seconds"
+                            )
+
+                        if current_time - last_chunk_time > 60 and full_content:
+                            logger.warning(
+                                "No response for over 60 seconds, triggering recovery mechanism"
+                            )
+                            translations = get_translation(
+                                self.config.get('language', 'en')
+                            )
+                            raise requests.exceptions.ReadTimeout(
+                                translations.get(
+                                    'stream_timeout_error',
+                                    "Streaming timeout after 60 seconds with no new content, possible connection issue",
+                                )
+                            )
+
+                logger.info(
+                    f"Streaming completed, received {chunk_count} chunks, total length: {len(full_content)}"
                 )
-                response.raise_for_status()
-                
-                result = response.json()
-                if 'choices' in result and result['choices']:
-                    return result['choices'][0]['message']['content']
-                else:
-                    translations = get_translation(self.config.get('language', 'en'))
-                    raise Exception(translations.get('invalid_response', 'Invalid API response format'))
-                    
+                return full_content
+
+            response = requests.post(
+                api_url,
+                headers=headers,
+                json=data,
+                timeout=kwargs.get('timeout', 60),
+            )
+            response.raise_for_status()
+
+            result = response.json()
+            content = self.extract_text_from_response(result)
+            if content:
+                return content
+
+            translations = get_translation(self.config.get('language', 'en'))
+            raise Exception(
+                translations.get('invalid_response', 'Invalid API response format')
+            )
+
         except requests.exceptions.RequestException as e:
-            logger = logging.getLogger('calibre_plugins.ask_ai_plugin.models.openai')
             logger.error(f"OpenAI API request error: {str(e)}")
             translations = get_translation(self.config.get('language', 'en'))
-            raise Exception(translations.get('api_request_failed', 'API request failed: {error}').format(error=str(e)))
-    
+            error_msg = translations.get(
+                'api_request_failed',
+                'API request failed: {error}',
+            ).format(error=str(e))
+            if hasattr(e, 'response') and e.response is not None:
+                try:
+                    detail = e.response.json()
+                    message = (detail.get('error') or {}).get('message')
+                    if message:
+                        error_msg = f"{error_msg} | {message}"
+                except Exception:
+                    pass
+            raise Exception(error_msg) from e
+
     def send_message(self, prompt: str, callback: callable) -> None:
         """
         Send message and stream response via callback
-        
+
         :param prompt: Prompt text
         :param callback: Callback function to receive streaming text
         """
         try:
             self.ask(prompt, stream=True, stream_callback=callback)
         except Exception as e:
-            logger = logging.getLogger('calibre_plugins.ask_ai_plugin.models.openai')
             logger.error(f"send_message error: {str(e)}")
             raise
-    
+
     def stop_stream(self) -> None:
         """
         Stop streaming response
         Note: Current implementation does not support mid-stream interruption
         """
         pass
-    
+
     def get_model_name(self) -> str:
         """
         Get current model name
-        
+
         :return: Model name string
         """
         return self.config.get('model', self.DEFAULT_MODEL)
-    
+
     def get_provider_name(self) -> str:
         """
         Get provider name
-        
+
         :return: Provider name string
         """
         return "OpenAI"
-    
+
     def supports_streaming(self) -> bool:
         """
         Check if model supports streaming
-        
+
         :return: True if streaming is supported
         """
-        return True  # OpenAI supports streaming
-    
-    # OpenAI 使用基类的默认实现，无需重写 fetch_available_models
-    # 基类已经提供了完整的 OpenAI 兼容实现
+        return True
+
+    @classmethod
+    def get_default_config(cls) -> Dict[str, Any]:
+        """
+        Get OpenAI model default configuration
+
+        :return: Default configuration dictionary
+        """
+        return {
+            "api_key": "",
+            "api_base_url": cls.DEFAULT_API_BASE_URL,
+            "model": cls.DEFAULT_MODEL,
+            "enable_streaming": True,
+        }
+
+    def verify_api_key_with_test_request(self) -> None:
+        """
+        Verify API key against Responses API (not Chat Completions).
+        """
+        provider_name = self.get_provider_name()
+        timeout_seconds = 15
+
+        try:
+            headers = self.prepare_headers()
+            api_base_url = self.config.get('api_base_url', self.DEFAULT_API_BASE_URL)
+            test_url = self.build_api_url(api_base_url, '/responses')
+            test_data = self.prepare_request_data("hi", max_tokens=16, stream=False)
+
+            logger.info(f"[{provider_name}] 发送测试请求验证 API Key: {test_url}")
+
+            response = requests.post(
+                test_url,
+                headers=headers,
+                json=test_data,
+                timeout=timeout_seconds,
+            )
+
+            logger.info(f"[{provider_name}] 测试请求响应状态码: {response.status_code}")
+            logger.debug(f"[{provider_name}] 测试请求响应内容: {response.text[:200]}")
+
+            if response.status_code == 401:
+                translations = get_translation(self.config.get('language', 'en'))
+                error_msg = translations.get(
+                    'error_401',
+                    'API Key authentication failed. Please check: API Key is correct, '
+                    'account has sufficient balance, API Key has not expired.',
+                )
+                tech_details = translations.get('technical_details', 'Technical Details')
+                raise Exception(
+                    f"{error_msg}\n\n{tech_details}: HTTP 401 - Invalid API Key"
+                )
+
+            if response.status_code == 404:
+                translations = get_translation(self.config.get('language', 'en'))
+                error_msg = translations.get(
+                    'error_404',
+                    'API endpoint not found. Please check if the API Base URL configuration is correct.',
+                )
+                tech_details = translations.get('technical_details', 'Technical Details')
+                raise Exception(
+                    f"{error_msg}\n\n{tech_details}: HTTP 404 - This may indicate an invalid API Key or insufficient permissions."
+                )
+
+            if response.status_code in [200, 400, 422]:
+                logger.info(
+                    f"[{provider_name}] API Key 验证成功 - 状态码: {response.status_code}"
+                )
+            else:
+                logger.warning(
+                    f"[{provider_name}] 收到未预期的状态码: {response.status_code}"
+                )
+
+        except requests.exceptions.Timeout as e:
+            logger.error(f"[{provider_name}] API Key 验证请求超时: {str(e)}")
+            translations = get_translation(self.config.get('language', 'en'))
+            error_msg = translations.get(
+                'error_network',
+                'Network connection failed. Please check network connection, '
+                'proxy settings, or firewall configuration.',
+            )
+            tech_details = translations.get('technical_details', 'Technical Details')
+            raise Exception(
+                f"{error_msg}\n\n{tech_details}: Timeout after {timeout_seconds} seconds"
+            )
+
+        except requests.exceptions.RequestException as e:
+            logger.error(f"[{provider_name}] API Key 验证请求失败: {str(e)}")
+            if hasattr(e, 'response') and e.response is not None:
+                if e.response.status_code in [401, 403]:
+                    translations = get_translation(self.config.get('language', 'en'))
+                    error_msg = translations.get(
+                        'error_401',
+                        'API Key authentication failed. Please check: API Key is correct, '
+                        'account has sufficient balance, API Key has not expired.',
+                    )
+                    tech_details = translations.get('technical_details', 'Technical Details')
+                    raise Exception(f"{error_msg}\n\n{tech_details}: {str(e)}")
+            logger.info(f"[{provider_name}] API Key 验证通过（收到非401/403响应）")
+
+    # Models list still uses GET /v1/models (OpenAI-compatible, covered by BaseAIModel)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Anthropic (Claude) and OpenAI (ChatGPT) providers to match current official request protocols.

## Anthropic (Messages API)

- Keep `x-api-key` + `anthropic-version: 2023-06-01` + `/v1/messages`
- System prompt via top-level `system`
- **Omit `temperature` / `top_p` / `top_k` for Claude Opus 4.7+** (these now return 400)
- Parse all `content[]` text blocks (and thinking blocks when present)
- Models list via `GET /v1/models` with proper headers (no GET `Content-Type`)
- Docs updated in `aiprovider/anthropic.md`

## OpenAI / ChatGPT (Responses API)

- Migrate from `/v1/chat/completions` to **`/v1/responses`**
- Use `instructions` + `input` instead of `messages`
- Use `max_output_tokens` instead of `max_tokens`
- Default `store: false` so book Q&A is not persisted server-side
- Stream via `response.output_text.delta`
- Key verification and ask path both use Responses
- New docs: `aiprovider/openai.md`; `openai_compatible.md` clarified for other providers

Other OpenAI-compatible providers (DeepSeek, OpenRouter, Custom, etc.) remain on Chat Completions.

## Test plan

- [x] Static protocol checks + `py_compile` for both model modules
- [ ] Anthropic: configure Claude Opus 4.8 key → ask (confirm no 400 from temperature)
- [ ] Anthropic: refresh model list via `/v1/models`
- [ ] OpenAI: configure ChatGPT key → ask via Responses (stream + non-stream)
- [ ] OpenAI: confirm API key test uses `/responses`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f77e2-e367-7ddc-b566-0656e4060a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f77e2-e367-7ddc-b566-0656e4060a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

